### PR TITLE
CLI via Sidecar HTTP Proxy 

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,11 @@ import (
 func setup(app *ccli.App) {
 	app.Flags = append(app.Flags,
 		ccli.StringFlag{
+			Name:   "proxy_address",
+			Usage:  "Proxy requests via the HTTP address specified",
+			EnvVar: "MICRO_PROXY_ADDRESS",
+		},
+		ccli.StringFlag{
 			Name:   "api_address",
 			Usage:  "Set the api address e.g 0.0.0.0:8080",
 			EnvVar: "MICRO_API_ADDRESS",

--- a/web/templates.go
+++ b/web/templates.go
@@ -156,10 +156,8 @@ var (
 		</tbody>
 	</table>
 	{{end}}
-        {{if $svc.Endpoints}}
 	<h4>Endpoints</h4>
 	<hr/>
-        {{end}}
 	{{with $svc := index . 0}}{{range $svc.Endpoints}}
 		<h4>{{.Name}}</h4>
 		<table class="table table-bordered">

--- a/web/web.go
+++ b/web/web.go
@@ -142,6 +142,8 @@ func indexHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	sort.Strings(webServices)
+
 	type templateData struct {
 		HasWebServices bool
 		WebServices    []string


### PR DESCRIPTION
This allows using the CLI via the sidecar. For staging, production, etc it means we can use a http(s)? url rather than having to connect to the registry directly.