### PR TITLE
Add an API proxy; useful for REST

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -2,7 +2,7 @@
 
 This is a lightweight proxy for [Micro](https://github.com/micro/micro) based microservices. It conforms to the [API Gateway](http://microservices.io/patterns/apigateway.html) pattern and can be used in conjuction with [go-micro](https://github.com/micro/go-micro) based apps or any future language implementation of the [Micro](https://github.com/micro/micro) toolchain.
 
-The API serves requests in two ways.
+The API serves requests in three ways.
 
 1. /rpc
 	- Sends requests directly to backend services using JSON
@@ -12,8 +12,9 @@ The API serves requests in two ways.
 	- Requests are sent to a special type of API service which takes the request api.Request and response api.Response. 
 	- Definitions can be found at [micro/api/proto](https://github.com/micro/micro/tree/master/api/proto)
 
-
-
+3. /[service] proxy set via `--api_translator=proxy`
+	- The request will be reverse proxied to the served resolved by the first element in the path
+	- This allows REST to be implemented behind the API
 
 ## Getting started
 
@@ -109,6 +110,22 @@ Path	|	Service	|	Method
 /v2/foo/bar/baz	|	go.micro.api.v2.foo	|	Bar.Baz
 
 A working example can be found here [Greeter Service](https://github.com/micro/micro/tree/master/examples/greeter)
+
+## Using REST
+
+You can serve a RESTful API by using the API as a proxy and implementing RESTful paths with libraries such as [go-restful](https://github.com/emicklei/go-restful). 
+An example of a REST API service can be found at [greeter/api/go-restful](https://github.com/micro/micro/tree/master/examples/greeter/api/go-restful).
+
+Starting the API with `--api_translator=proxy` will reverse proxy requests to backend services within the served API namespace (default: go.micro.api). 
+The /[service] prefix is stripped with web services but with the API we preserve it, so you'll receive the full PATH for the request.
+
+Example
+
+Path	|	Service	|	Service Path
+---	|	---
+/greeter	|	go.micro.api.greeter	|	/greeter
+/greeter/:name	|	go.micro.api.greeter	|	/greeter/:name
+
 
 ## Stats Dashboard
 

--- a/api/README.md
+++ b/api/README.md
@@ -117,12 +117,11 @@ You can serve a RESTful API by using the API as a proxy and implementing RESTful
 An example of a REST API service can be found at [greeter/api/go-restful](https://github.com/micro/micro/tree/master/examples/greeter/api/go-restful).
 
 Starting the API with `--api_translator=proxy` will reverse proxy requests to backend services within the served API namespace (default: go.micro.api). 
-The /[service] prefix is stripped with web services but with the API we preserve it, so you'll receive the full PATH for the request.
 
 Example
 
 Path	|	Service	|	Service Path
----	|	---
+---	|	---	|	---
 /greeter	|	go.micro.api.greeter	|	/greeter
 /greeter/:name	|	go.micro.api.greeter	|	/greeter/:name
 

--- a/api/README.md
+++ b/api/README.md
@@ -12,7 +12,7 @@ The API serves requests in three ways.
 	- Requests are sent to a special type of API service which takes the request api.Request and response api.Response. 
 	- Definitions can be found at [micro/api/proto](https://github.com/micro/micro/tree/master/api/proto)
 
-3. /[service] proxy set via `--api_translator=proxy`
+3. /[service] proxy set via `--api_handler=proxy`
 	- The request will be reverse proxied to the served resolved by the first element in the path
 	- This allows REST to be implemented behind the API
 
@@ -116,7 +116,7 @@ A working example can be found here [Greeter Service](https://github.com/micro/m
 You can serve a RESTful API by using the API as a proxy and implementing RESTful paths with libraries such as [go-restful](https://github.com/emicklei/go-restful). 
 An example of a REST API service can be found at [greeter/api/go-restful](https://github.com/micro/micro/tree/master/examples/greeter/api/go-restful).
 
-Starting the API with `--api_translator=proxy` will reverse proxy requests to backend services within the served API namespace (default: go.micro.api). 
+Starting the API with `--api_handler=proxy` will reverse proxy requests to backend services within the served API namespace (default: go.micro.api). 
 
 Example
 

--- a/api/README.md
+++ b/api/README.md
@@ -2,18 +2,20 @@
 
 This is a lightweight proxy for [Micro](https://github.com/micro/micro) based microservices. It conforms to the [API Gateway](http://microservices.io/patterns/apigateway.html) pattern and can be used in conjuction with [go-micro](https://github.com/micro/go-micro) based apps or any future language implementation of the [Micro](https://github.com/micro/micro) toolchain.
 
-The API serves requests in three ways.
+## Handlers
+
+The API handles requests in three ways.
 
 1. /rpc
 	- Sends requests directly to backend services using JSON
 	- Expects params: service, method, request.
 2. /[service]/[method]
 	- The path is used to resolve service and method. 
-	- Requests are sent to a special type of API service which takes the request api.Request and response api.Response. 
-	- Definitions can be found at [micro/api/proto](https://github.com/micro/micro/tree/master/api/proto)
+	- Requests are handled via API services which take the request api.Request and response api.Response types. 
+	- Definitions for the Request/Response can be found at [micro/api/proto](https://github.com/micro/micro/tree/master/api/proto)
 
-3. /[service] proxy set via `--api_handler=proxy`
-	- The request will be reverse proxied to the served resolved by the first element in the path
+3. /[service] reverse proxy set via `--api_handler=proxy`
+	- The request will be reverse proxied to the service resolved by the first element in the path
 	- This allows REST to be implemented behind the API
 
 ## Getting started
@@ -54,7 +56,10 @@ micro --api_namespace=com.example.api
 
 ## Testing API
 
+### Run the example app
+
 Let's start the example [go-micro](https://github.com/micro/go-micro) based server.
+
 ```bash
 $ go get github.com/micro/go-micro/examples/server
 $ $GOPATH/bin/server 
@@ -63,8 +68,10 @@ I0525 18:17:57.574748   84421 rpc_server.go:126] Listening on [::]:62421
 I0525 18:17:57.574779   84421 server.go:99] Registering node: go.micro.srv.example-fccbb6fb-0301-11e5-9f1f-68a86d0d36b6
 ```
 
-The example server has a handler registered called Example with a method named Call. 
-Now let's query this through the API. 
+### Query RPC via curl
+
+The example server has a handler registered called Example with a method named Call. Now let's query this through the API.
+
 ```bash
 $ curl -d 'service=go.micro.srv.example' \
 	-d 'method=Example.Call' \
@@ -75,6 +82,7 @@ $ curl -d 'service=go.micro.srv.example' \
 ```
 
 Alternatively let's try 'Content-Type: application/json'
+
 ```bash
 $ curl -H 'Content-Type: application/json' \
 	-d '{"service": "go.micro.srv.example", "method": "Example.Call", "request": {"name": "Asim Aslam"}}' \
@@ -83,11 +91,15 @@ $ curl -H 'Content-Type: application/json' \
 {"msg":"go.micro.srv.example-fccbb6fb-0301-11e5-9f1f-68a86d0d36b6: Hello Asim Aslam"}
 ```
 
-## Testing path resolution using API Services
+## API HTTP request translation
 
-Micro allows you resolve HTTP Paths at the edge as individual API Services. An API service is like any other 
-micro service except each method signature takes an *api.Request and *api.Response which can be found in 
+Micro allows you resolve HTTP Paths at the edge to individual API Services. An API service is like any other 
+micro service except each method signature takes an *api.Request and *api.Response type which can be found in 
 [github.com/micro/micro/api/proto](https://github.com/micro/micro/tree/master/api/proto).
+
+The http.Request is deconstructed by the API into an api.Request and forwarded on to a backend API service. 
+The api.Response is then constructed into a http.Response and returned to the client. The path of the request 
+along with a namespace, is used to determine the backend service and method to call.
 
 The default namespace for these services are **go.micro.api** but you can set your own namespace via `--api_namespace`.
 

--- a/api/api.go
+++ b/api/api.go
@@ -81,7 +81,7 @@ func run(ctx *cli.Context) {
 	switch ctx.GlobalString("api_translator") {
 	case "proxy":
 		log.Infof("Registering API Proxy Handler at %s", ProxyPath)
-		r.PathPrefix(ProxyPath).Handler(handler.Proxy(Namespace))
+		r.PathPrefix(ProxyPath).Handler(handler.Proxy(Namespace, false))
 	default:
 		log.Infof("Registering API Handler at %s", APIPath)
 		r.HandleFunc(APIPath, restHandler)

--- a/api/api.go
+++ b/api/api.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	log "github.com/golang/glog"
+	"github.com/gorilla/mux"
 	"github.com/micro/cli"
 	"github.com/micro/go-micro"
 	"github.com/micro/micro/internal/handler"
@@ -18,13 +19,14 @@ var (
 	Address      = ":8080"
 	RPCPath      = "/rpc"
 	APIPath      = "/"
+	ProxyPath    = "/{service:[a-zA-Z0-9]+}"
 	Namespace    = "go.micro.api"
 	HeaderPrefix = "X-Micro-"
 	CORS         = map[string]bool{"*": true}
 )
 
 type srv struct {
-	*http.ServeMux
+	*mux.Router
 }
 
 func (s *srv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +44,7 @@ func (s *srv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.ServeMux.ServeHTTP(w, r)
+	s.Router.ServeHTTP(w, r)
 }
 
 func run(ctx *cli.Context) {
@@ -71,11 +73,19 @@ func run(ctx *cli.Context) {
 	}
 
 	// create the router
-	r := http.NewServeMux()
+	r := mux.NewRouter()
+
 	log.Infof("Registering RPC Handler at %s", RPCPath)
 	r.HandleFunc(RPCPath, handler.RPC)
-	log.Infof("Registering API Handler at %s", APIPath)
-	r.HandleFunc(APIPath, restHandler)
+
+	switch ctx.GlobalString("api_translator") {
+	case "proxy":
+		log.Infof("Registering API Proxy Handler at %s", ProxyPath)
+		r.PathPrefix(ProxyPath).Handler(handler.Proxy(Namespace))
+	default:
+		log.Infof("Registering API Handler at %s", APIPath)
+		r.HandleFunc(APIPath, restHandler)
+	}
 
 	s := &srv{r}
 	var h http.Handler = s

--- a/api/api.go
+++ b/api/api.go
@@ -94,7 +94,7 @@ func run(ctx *cli.Context) {
 		r.PathPrefix(ProxyPath).Handler(handler.Proxy(Namespace, false))
 	default:
 		log.Infof("Registering API Handler at %s", APIPath)
-		r.PathPrefix(APIPath).HandlerFunc(restHandler)
+		r.PathPrefix(APIPath).HandlerFunc(apiHandler)
 	}
 
 	// create the server

--- a/api/handler.go
+++ b/api/handler.go
@@ -102,7 +102,7 @@ func requestToProto(r *http.Request) (*api.Request, error) {
 	return req, nil
 }
 
-func restHandler(w http.ResponseWriter, r *http.Request) {
+func apiHandler(w http.ResponseWriter, r *http.Request) {
 	request, err := requestToProto(r)
 	if err != nil {
 		er := errors.InternalServerError("go.micro.api", err.Error())

--- a/examples/greeter/api/go-restful/README.md
+++ b/examples/greeter/api/go-restful/README.md
@@ -1,0 +1,42 @@
+# Go Restful API Example
+
+This is an example of how to serve REST behind the API using go-restful
+
+## Getting Started
+
+### Run the Micro API
+
+```
+$ micro --api_translator=proxy api
+```
+
+### Run the Greeter Service
+
+```
+$ go run greeter/server/main.go
+```
+
+### Run the Greeter API
+
+```
+$ go run go-restful.go
+Listening on [::]:64738
+```
+
+### Curl the API
+
+Test the index
+```
+curl http://localhost:8080/greeter
+{
+  "message": "Hi, this is the Greeter API"
+}
+```
+
+Test a resource
+```
+ curl http://localhost:8080/greeter/asim
+{
+  "msg": "Hello asim"
+}
+```

--- a/examples/greeter/api/go-restful/go-restful.go
+++ b/examples/greeter/api/go-restful/go-restful.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"github.com/emicklei/go-restful"
+	log "github.com/golang/glog"
+
+	"github.com/micro/go-micro/client"
+	"github.com/micro/go-web"
+	hello "github.com/micro/micro/examples/greeter/server/proto/hello"
+
+	"golang.org/x/net/context"
+)
+
+type Say struct{}
+
+var (
+	cl hello.SayClient
+)
+
+func (s *Say) Anything(req *restful.Request, rsp *restful.Response) {
+	log.Info("Received Say.Anything API request")
+	rsp.WriteEntity(map[string]string{
+		"message": "Hi, this is the Greeter API",
+	})
+}
+
+func (s *Say) Hello(req *restful.Request, rsp *restful.Response) {
+	log.Info("Received Say.Hello API request")
+
+	name := req.PathParameter("name")
+
+	response, err := cl.Hello(context.TODO(), &hello.Request{
+		Name: name,
+	})
+
+	if err != nil {
+		rsp.WriteError(500, err)
+	}
+
+	rsp.WriteEntity(response)
+}
+
+func main() {
+	// Create service
+	service := web.NewService(
+		web.Name("go.micro.api.greeter"),
+	)
+
+	service.Init()
+
+	// setup Greeter Server Client
+	cl = hello.NewSayClient("go.micro.srv.greeter", client.DefaultClient)
+
+	// Create RESTful handler
+	say := new(Say)
+	ws := new(restful.WebService)
+	wc := restful.NewContainer()
+	ws.Consumes(restful.MIME_XML, restful.MIME_JSON)
+	ws.Produces(restful.MIME_JSON, restful.MIME_XML)
+	ws.Path("/greeter")
+	ws.Route(ws.GET("/").To(say.Anything))
+	ws.Route(ws.GET("/{name}").To(say.Hello))
+	wc.Add(ws)
+
+	// Register Handler
+	service.Handle("/", wc)
+
+	// Run server
+	if err := service.Run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"regexp"
+	"strings"
+
+	"github.com/micro/go-micro/cmd"
+	"github.com/micro/go-micro/selector"
+)
+
+type proxy struct {
+	Default  *httputil.ReverseProxy
+	Director func(r *http.Request)
+}
+
+func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !isWebSocket(r) {
+		// the usual path
+		p.Default.ServeHTTP(w, r)
+		return
+	}
+
+	// the websocket path
+	req := new(http.Request)
+	*req = *r
+	p.Director(req)
+	host := req.URL.Host
+
+	if len(host) == 0 {
+		http.Error(w, "invalid host", 500)
+		return
+	}
+
+	// connect to the backend host
+	conn, err := net.Dial("tcp", host)
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+
+	// hijack the connection
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "failed to connect", 500)
+		return
+	}
+
+	nc, _, err := hj.Hijack()
+	if err != nil {
+		return
+	}
+
+	defer nc.Close()
+	defer conn.Close()
+
+	if err = req.Write(conn); err != nil {
+		return
+	}
+
+	errCh := make(chan error, 2)
+
+	cp := func(dst io.Writer, src io.Reader) {
+		_, err := io.Copy(dst, src)
+		errCh <- err
+	}
+
+	go cp(conn, nc)
+	go cp(nc, conn)
+
+	<-errCh
+}
+
+func isWebSocket(r *http.Request) bool {
+	contains := func(key, val string) bool {
+		vv := strings.Split(r.Header.Get(key), ",")
+		for _, v := range vv {
+			if val == strings.ToLower(strings.TrimSpace(v)) {
+				return true
+			}
+		}
+		return false
+	}
+
+	if contains("Connection", "upgrade") && contains("Upgrade", "websocket") {
+		return true
+	}
+
+	return false
+}
+
+func Proxy(ns string) http.Handler {
+	sel := selector.NewSelector(
+		selector.Registry((*cmd.DefaultOptions().Registry)),
+	)
+
+	re := regexp.MustCompile("^[a-zA-Z0-9]+$")
+
+	director := func(r *http.Request) {
+		kill := func() {
+			r.URL.Host = ""
+			r.URL.Path = ""
+			r.URL.Scheme = ""
+			r.Host = ""
+			r.RequestURI = ""
+		}
+
+		parts := strings.Split(r.URL.Path, "/")
+		if len(parts) < 2 {
+			kill()
+			return
+		}
+		if !re.MatchString(parts[1]) {
+			kill()
+			return
+		}
+		next, err := sel.Select(ns + "." + parts[1])
+		if err != nil {
+			kill()
+			return
+		}
+
+		s, err := next()
+		if err != nil {
+			kill()
+			return
+		}
+
+		r.URL.Host = fmt.Sprintf("%s:%d", s.Address, s.Port)
+		r.URL.Scheme = "http"
+	}
+
+	return &proxy{
+		Default:  &httputil.ReverseProxy{Director: director},
+		Director: director,
+	}
+}

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -93,7 +93,7 @@ func isWebSocket(r *http.Request) bool {
 	return false
 }
 
-func Proxy(ns string) http.Handler {
+func Proxy(ns string, ws bool) http.Handler {
 	sel := selector.NewSelector(
 		selector.Registry((*cmd.DefaultOptions().Registry)),
 	)
@@ -134,8 +134,15 @@ func Proxy(ns string) http.Handler {
 		r.URL.Scheme = "http"
 	}
 
+	dr := &httputil.ReverseProxy{Director: director}
+
+	// disable web sockets
+	if !ws {
+		return dr
+	}
+
 	return &proxy{
-		Default:  &httputil.ReverseProxy{Director: director},
+		Default:  dr,
 		Director: director,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -59,9 +59,9 @@ func setup(app *ccli.App) {
 			Usage:  "Register interval in seconds",
 		},
 		ccli.StringFlag{
-			Name:   "api_translator",
-			Usage:  "Specify the request translator to be used mapping to backend services. e.g api, proxy",
-			EnvVar: "MICRO_API_TRANSLATOR",
+			Name:   "api_handler",
+			Usage:  "Specify the request handler to be used for mapping HTTP requests to services. e.g api, proxy",
+			EnvVar: "MICRO_API_HANDLER",
 		},
 		ccli.StringFlag{
 			Name:   "api_namespace",

--- a/main.go
+++ b/main.go
@@ -59,6 +59,11 @@ func setup(app *ccli.App) {
 			Usage:  "Register interval in seconds",
 		},
 		ccli.StringFlag{
+			Name:   "api_translator",
+			Usage:  "Specify the request translator to be used mapping to backend services. e.g api, proxy",
+			EnvVar: "MICRO_API_TRANSLATOR",
+		},
+		ccli.StringFlag{
 			Name:   "api_namespace",
 			Usage:  "Set the namespace used by the API e.g. com.example.api",
 			EnvVar: "MICRO_API_NAMESPACE",


### PR DESCRIPTION
This PR adds the ability to switch the API translator from api.{Request,Response} to reverse proxying much like the Web Proxy. This is useful for where something like REST resources may need to be implement in the API layer.

The translator can be used by specifying `--api_translator=proxy` on the command line. In the future we may add additional translators and also allow specifying something like "metadata" or "config" so the translation is done dynamically based on whats in the service registry.

The reason for duplicating the reverse proxying behaviour from the web proxy is to add additional functionality specific to serving an API while also stripping the ability to do such things as serving web pages.