### PR TITLE
Improve /rpc endpoint to accept embedded JSON objects as requests

### DIFF
--- a/internal/handler/rpc.go
+++ b/internal/handler/rpc.go
@@ -53,16 +53,6 @@ func RPC(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if len(body.Service) == 0 {
-			badRequest("invalid service")
-			return
-		}
-
-		if len(body.Method) == 0 {
-			badRequest("invalid method")
-			return
-		}
-
 		service = body.Service
 		method = body.Method
 		address = body.Address
@@ -80,7 +70,20 @@ func RPC(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()
 		service = r.Form.Get("service")
 		method = r.Form.Get("method")
-		json.Unmarshal([]byte(r.Form.Get("request")), &request)
+		if err := json.Unmarshal([]byte(r.Form.Get("request")), &request); err != nil {
+			badRequest("while decoding request string: " + err.Error())
+			return
+		}
+	}
+
+	if len(service) == 0 {
+		badRequest("invalid service")
+		return
+	}
+
+	if len(method) == 0 {
+		badRequest("invalid method")
+		return
 	}
 
 	var response map[string]interface{}


### PR DESCRIPTION
With this change, also embedded JSON objects will be accepted as "request"s, i.e. without them being wrapped in a string.

Before it was necessary to cruft (I mean craft) a request like this:

    '{"service":"foo.bar","method":"FooBar.FizzBuzz","request":"{\"trip\":{\"pickupDateTime\":\"2016-03-13T12:00:00Z\",\"returnDateTime\":\"2016-03-15T12:00:00Z\"},\"pointOfSaleCountry\":\"US\"}"}'

With this PR, also this more natural approach works:

    '{"service":"foo.bar","method":"FooBar.FizzBuzz","request":{"trip":{"pickupDateTime":"2016-03-13T12:00:00Z","returnDateTime":"2016-03-15T12:00:00Z"},"pointOfSaleCountry":"US"}}'

What do you think?