### PR TITLE
Remove parameters from Content-Type header

### DIFF
--- a/internal/handler/rpc.go
+++ b/internal/handler/rpc.go
@@ -39,7 +39,12 @@ func RPC(w http.ResponseWriter, r *http.Request) {
 	// response content type
 	w.Header().Set("Content-Type", "application/json")
 
-	switch r.Header.Get("Content-Type") {
+	// Remove parameters from Content-Type (like `application/json; charset=UTF-8`)
+	ct := r.Header.Get("Content-Type")
+	if idx := strings.IndexRune(ct, ';'); idx >= 0 {
+		ct = ct[:idx]
+	}
+	switch ct {
 	case "application/json":
 		var rpcReq rpcRequest
 


### PR DESCRIPTION
Some browsers send `application/json; charset=UTF-8` which the API gateway would not recognize as JSON.