### PR TITLE
Set Host: header to target for web proxied requests

### DIFF
--- a/web/web.go
+++ b/web/web.go
@@ -103,6 +103,7 @@ func (s *srv) proxy() http.Handler {
 		r.URL.Host = fmt.Sprintf("%s:%d", s.Address, s.Port)
 		r.URL.Path = "/" + strings.Join(parts[2:], "/")
 		r.URL.Scheme = "http"
+		r.Host = r.URL.Host
 	}
 
 	return &proxy{


### PR DESCRIPTION
See https://github.com/golang/go/issues/5692
This is useful if the web target is under a vhost, for example.