### PR TITLE
Add service whitelist for RPC calls

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -60,6 +60,14 @@ are used to resolve an API service and method to send the query to.
 micro --api_namespace=com.example.api
 ```
 
+### Whitelist Services
+
+If you don't want all services to be accessible via the RPC endpoint, specify a list of allowed services:
+
+```bash
+micro --api_rpc_whitelist=com.example.service.foo,com.example.service.bar
+```
+
 ## Testing API
 
 ### Run the example app

--- a/api/api.go
+++ b/api/api.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -80,8 +81,12 @@ func run(ctx *cli.Context) {
 		defer st.Stop()
 	}
 
+	var whitelistServices []string
+	if whitelist := ctx.GlobalString("api_rpc_whitelist"); len(whitelist) > 0 {
+		whitelistServices = strings.Split(whitelist, ",")
+	}
 	log.Printf("Registering RPC Handler at %s", RPCPath)
-	r.HandleFunc(RPCPath, handler.RPC)
+	r.Handle(RPCPath, handler.NewRPCWithWhitelist(whitelistServices...))
 
 	switch ctx.GlobalString("api_handler") {
 	case "proxy":

--- a/car/car.go
+++ b/car/car.go
@@ -77,7 +77,7 @@ func run(ctx *cli.Context, car *Sidecar) {
 	r.Handle(RegistryPath, http.HandlerFunc(handler.Registry))
 
 	log.Printf("Registering RPC handler at %s", RPCPath)
-	r.Handle(RPCPath, http.HandlerFunc(handler.RPC))
+	r.Handle(RPCPath, new(handler.RPC))
 
 	log.Printf("Registering Broker handler at %s", BrokerPath)
 	r.Handle(BrokerPath, http.HandlerFunc(handler.Broker))

--- a/internal/handler/rpc.go
+++ b/internal/handler/rpc.go
@@ -28,11 +28,9 @@ type RPC struct {
 // If no services are given, requests to all services are allowed .
 func NewRPCWithWhitelist(services ...string) *RPC {
 	rpc := new(RPC)
-	if len(services) > 0 {
-		rpc.whitelist = make(map[string]bool)
-		for _, service := range services {
-			rpc.whitelist[service] = true
-		}
+	rpc.whitelist = make(map[string]bool)
+	for _, service := range services {
+		rpc.whitelist[service] = true
 	}
 	return rpc
 }

--- a/main.go
+++ b/main.go
@@ -67,6 +67,11 @@ func setup(app *ccli.App) {
 			Usage:  "Register interval in seconds",
 		},
 		ccli.StringFlag{
+			Name:   "api_rpc_whitelist",
+			Usage:  "Comma separated whitelist of allowed services for RPC calls",
+			EnvVar: "MICRO_API_RPC_WHITELIST",
+		},
+		ccli.StringFlag{
 			Name:   "api_handler",
 			Usage:  "Specify the request handler to be used for mapping HTTP requests to services. e.g api, proxy",
 			EnvVar: "MICRO_API_HANDLER",

--- a/web/web.go
+++ b/web/web.go
@@ -325,7 +325,7 @@ func run(ctx *cli.Context) {
 	}
 
 	s.HandleFunc("/registry", registryHandler)
-	s.HandleFunc("/rpc", handler.RPC)
+	s.Handle("/rpc", new(handler.RPC))
 	s.HandleFunc("/cli", cliHandler)
 	s.HandleFunc("/query", queryHandler)
 	s.HandleFunc("/favicon.ico", faviconHandler)


### PR DESCRIPTION
This PR adds support for whitelisting services that can be called via the API gateways's RPC endpoint.

```bash
micro --api_rpc_whitelist=com.example.service.foo,com.example.service.bar
```
