### PR TITLE
Allow http OPTIONS requests

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -40,10 +40,6 @@ func (s *srv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 
-	if r.Method == "OPTIONS" {
-		return
-	}
-
 	s.Router.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
Allow APIs to self describe, so clients can consume it without knowing anything previosly.

On my use case, I can generate forms depending on OPTIONS request instead of harcoded them on the clients.