### PR TITLE
RPC handler type for the API

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -11,17 +11,25 @@ This is a lightweight proxy for [Micro](https://github.com/micro/micro) based mi
 
 The API handles requests in three ways.
 
-1. /rpc
-	- Sends requests directly to backend services using JSON
-	- Expects params: service, method, request.
-2. /[service]/[method]
-	- The path is used to resolve service and method. 
+1. Default Handler: /[service]/[method]
+	- The path is used to resolve service and method.
 	- Requests are handled via API services which take the request api.Request and response api.Response types. 
 	- Definitions for the Request/Response can be found at [micro/api/proto](https://github.com/micro/micro/tree/master/api/proto)
 
-3. /[service] reverse proxy set via `--api_handler=proxy`
+2. RPC Handler: /[service]/[method]
+	- An alternative to the default handler which uses the go-micro client to forward the request body as an RPC request.
+	- Allows API handlers to be defined with concrete Go types.
+	- Useful where you do not need full control of headers or request/response.
+	- Can be used to run a single layer of backend services rather than additional API services.
+	- set via `--api_handler=rpc`
+
+3. Reverse Proxy: /[service]
 	- The request will be reverse proxied to the service resolved by the first element in the path
 	- This allows REST to be implemented behind the API
+	- set via `--api_handler=proxy`
+4. /rpc
+	- Sends requests directly to backend services using JSON
+	- Expects params: `service`, `method`, `request`, optionally accepts `address` to target a specific host
 
 ## Getting started
 
@@ -96,6 +104,15 @@ $ curl -H 'Content-Type: application/json' \
 
 {"msg":"go.micro.srv.example-fccbb6fb-0301-11e5-9f1f-68a86d0d36b6: Hello Asim Aslam"}
 ```
+
+Or if the API is set with `--api_handler=rpc` and `--api_namespace=go.micro.srv`
+
+```bash
+$ curl -H 'Content-Type: application/json' -d '{"name": "Asim Aslam"}' http://localhost:8080/example/call
+
+{"msg":"go.micro.srv.example-fccbb6fb-0301-11e5-9f1f-68a86d0d36b6: Hello Asim Aslam"}
+```
+
 
 ## API HTTP request translation
 

--- a/api/api.go
+++ b/api/api.go
@@ -84,11 +84,14 @@ func run(ctx *cli.Context) {
 	r.HandleFunc(RPCPath, handler.RPC)
 
 	switch ctx.GlobalString("api_handler") {
+	case "rpc":
+		log.Printf("Registering API RPC Handler at %s", APIPath)
+		r.PathPrefix(APIPath).HandlerFunc(rpcHandler)
 	case "proxy":
 		log.Printf("Registering API Proxy Handler at %s", ProxyPath)
 		r.PathPrefix(ProxyPath).Handler(handler.Proxy(Namespace, false))
 	default:
-		log.Printf("Registering API Handler at %s", APIPath)
+		log.Printf("Registering API Default Handler at %s", APIPath)
 		r.PathPrefix(APIPath).HandlerFunc(apiHandler)
 	}
 

--- a/api/handler.go
+++ b/api/handler.go
@@ -207,20 +207,19 @@ func rpcHandler(w http.ResponseWriter, r *http.Request) {
 		// response content type
 		w.Header().Set("Content-Type", "application/json")
 
-		var request interface{}
-		d := json.NewDecoder(r.Body)
-		d.UseNumber()
-
-		// decode request; can we avoid this?
-		if err := d.Decode(&request); err != nil {
+		// get request
+		br, err := ioutil.ReadAll(r.Body)
+		if err != nil {
 			e := errors.InternalServerError("go.micro.api", err.Error())
 			http.Error(w, e.Error(), 500)
 			return
 		}
+		// use as raw json
+		request := json.RawMessage(br)
 
 		// create request/response
 		var response json.RawMessage
-		req := (*cmd.DefaultOptions().Client).NewJsonRequest(service, method, request)
+		req := (*cmd.DefaultOptions().Client).NewJsonRequest(service, method, &request)
 
 		// create context
 		ctx := helper.RequestToContext(r)


### PR DESCRIPTION
The API currently supports two modes. 

1. Default - Accept api.Request/Response that deconstructs http into rpc
2. Proxy - Reverse proxy and pass through everything to the backend

In some cases you may not want the overhead of handling api.Request/Response and still want the benefits of RPC. This PR introduces a new RPC handler for this. 