### PR TITLE
Handle Content-Type application/proto via API

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -15,18 +15,19 @@ The API handles requests in three ways.
 	- The path is used to resolve service and method.
 	- Requests are handled via API services which take the request api.Request and response api.Response types. 
 	- Definitions for the Request/Response can be found at [micro/api/proto](https://github.com/micro/micro/tree/master/api/proto)
-
-2. RPC Handler: /[service]/[method]
+	- The content type of the request/response body can be anything.
+	- The default handler
+2. RPC Handler: /[service]/[method
 	- An alternative to the default handler which uses the go-micro client to forward the request body as an RPC request.
 	- Allows API handlers to be defined with concrete Go types.
 	- Useful where you do not need full control of headers or request/response.
 	- Can be used to run a single layer of backend services rather than additional API services.
-	- set via `--api_handler=rpc`
-
+	- Supported content-type `application/json` and `application/proto`.
+	- Set via `--api_handler=rpc`
 3. Reverse Proxy: /[service]
 	- The request will be reverse proxied to the service resolved by the first element in the path
 	- This allows REST to be implemented behind the API
-	- set via `--api_handler=proxy`
+	- Set via `--api_handler=proxy`
 4. /rpc
 	- Sends requests directly to backend services using JSON
 	- Expects params: `service`, `method`, `request`, optionally accepts `address` to target a specific host

--- a/examples/greeter/client/api/api.go
+++ b/examples/greeter/client/api/api.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	hello "github.com/micro/micro/examples/greeter/api/rpc/proto/hello"
+	"io/ioutil"
+	"net/http"
+)
+
+func main() {
+	req, err := proto.Marshal(&hello.Request{Name: "John"})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
+	r, err := http.Post("http://localhost:8080/greeter/hello", "application/proto", bytes.NewReader(req))
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer r.Body.Close()
+
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	rsp := &hello.Response{}
+	if err := proto.Unmarshal(b, rsp); err != nil {
+		fmt.Println(err)
+		return
+	}
+	fmt.Println(rsp.Msg)
+}

--- a/internal/handler/proto/message.pb.go
+++ b/internal/handler/proto/message.pb.go
@@ -1,0 +1,28 @@
+package proto
+
+type Message struct {
+	data []byte
+}
+
+func (m *Message) ProtoMessage() {}
+
+func (m *Message) Reset() {
+	*m = Message{}
+}
+
+func (m *Message) String() string {
+	return string(m.data)
+}
+
+func (m *Message) Marshal() ([]byte, error) {
+	return m.data, nil
+}
+
+func (m *Message) Unmarshal(data []byte) error {
+	m.data = data
+	return nil
+}
+
+func NewMessage(data []byte) *Message {
+	return &Message{data}
+}


### PR DESCRIPTION
This PR introduces the ability to handle proto messages via the API. We essentially pass through the message uninterpreted to the RPC handler. This is useful where clients talking via the API want to reuse the concrete proto implementation but it's also more efficient than using JSON.