### PR TITLE
Sidecar to support the RPC root handler 

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -106,13 +106,13 @@ func run(ctx *cli.Context) {
 	switch Handler {
 	case "rpc":
 		log.Printf("Registering API RPC Handler at %s", APIPath)
-		r.PathPrefix(APIPath).HandlerFunc(rpcHandler)
+		r.PathPrefix(APIPath).Handler(handler.RPCX(Namespace))
 	case "proxy":
 		log.Printf("Registering API Proxy Handler at %s", ProxyPath)
 		r.PathPrefix(ProxyPath).Handler(handler.Proxy(Namespace, false))
 	default:
 		log.Printf("Registering API Default Handler at %s", APIPath)
-		r.PathPrefix(APIPath).HandlerFunc(apiHandler)
+		r.PathPrefix(APIPath).Handler(handler.API(Namespace))
 	}
 
 	// reverse wrap handler

--- a/car/car.go
+++ b/car/car.go
@@ -39,7 +39,7 @@ var (
 	RegistryPath = "/registry"
 	RPCPath      = "/rpc"
 	CORS         = map[string]bool{"*": true}
-	Namespace    string
+	Namespace    = "go.micro.srv"
 )
 
 func (s *srv) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/examples/greeter/client/sidecar/sidecar.go
+++ b/examples/greeter/client/sidecar/sidecar.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/golang/protobuf/proto"
-	hello "github.com/micro/micro/examples/greeter/api/rpc/proto/hello"
+	hello "github.com/micro/micro/examples/greeter/server/proto/hello"
 )
 
 func main() {
@@ -17,7 +17,7 @@ func main() {
 		return
 	}
 
-	r, err := http.Post("http://localhost:8080/greeter/hello", "application/protobuf", bytes.NewReader(req))
+	r, err := http.Post("http://localhost:8081/greeter/say/hello", "application/protobuf", bytes.NewReader(req))
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/internal/handler/api.go
+++ b/internal/handler/api.go
@@ -1,7 +1,6 @@
-package api
+package handler
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"mime"
@@ -9,13 +8,11 @@ import (
 	"net/http"
 	"path"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/micro/go-micro/cmd"
 	"github.com/micro/go-micro/errors"
 	api "github.com/micro/micro/api/proto"
-	proto "github.com/micro/micro/internal/handler/proto"
 	"github.com/micro/micro/internal/helper"
 )
 
@@ -23,9 +20,13 @@ var (
 	versionRe = regexp.MustCompilePOSIX("^v[0-9]+$")
 )
 
+type apiHandler struct {
+	Namespace string
+}
+
 // Translates /foo/bar/zool into api service go.micro.api.foo method Bar.Zool
 // Translates /foo/bar into api service go.micro.api.foo method Foo.Bar
-func pathToReceiver(p string) (string, string) {
+func pathToReceiver(ns, p string) (string, string) {
 	p = path.Clean(p)
 	p = strings.TrimPrefix(p, "/")
 	parts := strings.Split(p, "/")
@@ -34,7 +35,7 @@ func pathToReceiver(p string) (string, string) {
 	// Use first part as service
 	// Use all parts as method
 	if len(parts) <= 2 {
-		service := Namespace + "." + strings.Join(parts[:len(parts)-1], ".")
+		service := ns + "." + strings.Join(parts[:len(parts)-1], ".")
 		method := strings.Title(strings.Join(parts, "."))
 		return service, method
 	}
@@ -42,14 +43,14 @@ func pathToReceiver(p string) (string, string) {
 	// Treat /v[0-9]+ as versioning where we have 3 parts
 	// /v1/foo/bar => service: v1.foo method: Foo.bar
 	if len(parts) == 3 && versionRe.Match([]byte(parts[0])) {
-		service := Namespace + "." + strings.Join(parts[:len(parts)-1], ".")
+		service := ns + "." + strings.Join(parts[:len(parts)-1], ".")
 		method := strings.Title(strings.Join(parts[len(parts)-2:], "."))
 		return service, method
 	}
 
 	// Service is everything minus last two parts
 	// Method is the last two parts
-	service := Namespace + "." + strings.Join(parts[:len(parts)-2], ".")
+	service := ns + "." + strings.Join(parts[:len(parts)-2], ".")
 	method := strings.Title(strings.Join(parts[len(parts)-2:], "."))
 	return service, method
 }
@@ -138,8 +139,8 @@ func requestToProto(r *http.Request) (*api.Request, error) {
 	return req, nil
 }
 
-// apiHandler is the default handler which takes api.Request and returns api.Response
-func apiHandler(w http.ResponseWriter, r *http.Request) {
+// API handler is the default handler which takes api.Request and returns api.Response
+func (a *apiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	request, err := requestToProto(r)
 	if err != nil {
 		er := errors.InternalServerError("go.micro.api", err.Error())
@@ -150,7 +151,7 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// get service and method
-	service, method := pathToReceiver(r.URL.Path)
+	service, method := pathToReceiver(a.Namespace, r.URL.Path)
 
 	// create request and response
 	req := (*cmd.DefaultOptions().Client).NewRequest(service, method, request)
@@ -186,112 +187,8 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(rsp.Body))
 }
 
-// rpcHandler is an alternative handler which passes through an RPC request without modification
-func rpcHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	defer r.Body.Close()
-
-	// get service/method
-	service, method := pathToReceiver(r.URL.Path)
-	ct := r.Header.Get("Content-Type")
-
-	// Strip charset from Content-Type (like `application/json; charset=UTF-8`)
-	if idx := strings.IndexRune(ct, ';'); idx >= 0 {
-		ct = ct[:idx]
-	}
-
-	switch ct {
-	case "application/json":
-		// response content type
-		w.Header().Set("Content-Type", "application/json")
-
-		// get request
-		br, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			e := errors.InternalServerError("go.micro.api", err.Error())
-			http.Error(w, e.Error(), 500)
-			return
-		}
-		// use as raw json
-		request := json.RawMessage(br)
-
-		// create request/response
-		var response json.RawMessage
-		req := (*cmd.DefaultOptions().Client).NewJsonRequest(service, method, &request)
-
-		// create context
-		ctx := helper.RequestToContext(r)
-
-		// make the call
-		if err := (*cmd.DefaultOptions().Client).Call(ctx, req, &response); err != nil {
-			ce := errors.Parse(err.Error())
-			switch ce.Code {
-			case 0:
-				// assuming it's totally screwed
-				ce.Code = 500
-				ce.Id = "go.micro.api"
-				ce.Status = http.StatusText(500)
-				ce.Detail = "error during request: " + ce.Detail
-				w.WriteHeader(500)
-			default:
-				w.WriteHeader(int(ce.Code))
-			}
-			w.Write([]byte(ce.Error()))
-			return
-		}
-
-		b, _ := response.MarshalJSON()
-		w.Header().Set("Content-Length", strconv.Itoa(len(b)))
-		w.Write(b)
-	case "application/proto", "application/protobuf":
-		// get request
-		br, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			e := errors.InternalServerError("go.micro.api", err.Error())
-			http.Error(w, e.Error(), 500)
-			return
-		}
-
-		// use as raw proto
-		request := proto.NewMessage(br)
-
-		// create request/response
-		response := &proto.Message{}
-		req := (*cmd.DefaultOptions().Client).NewProtoRequest(service, method, request)
-
-		// create context
-		ctx := helper.RequestToContext(r)
-
-		// make the call
-		if err := (*cmd.DefaultOptions().Client).Call(ctx, req, response); err != nil {
-			ce := errors.Parse(err.Error())
-			switch ce.Code {
-			case 0:
-				// assuming it's totally screwed
-				ce.Code = 500
-				ce.Id = "go.micro.api"
-				ce.Status = http.StatusText(500)
-				ce.Detail = "error during request: " + ce.Detail
-				w.WriteHeader(500)
-			default:
-				w.WriteHeader(int(ce.Code))
-			}
-
-			// response content type
-			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(ce.Error()))
-			return
-		}
-
-		b, _ := response.Marshal()
-		w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
-		w.Header().Set("Content-Length", strconv.Itoa(len(b)))
-		w.Write(b)
-	default:
-		http.Error(w, "unknown content-type", 500)
-		return
+func API(namespace string) http.Handler {
+	return &apiHandler{
+		Namespace: namespace,
 	}
 }

--- a/internal/handler/api_test.go
+++ b/internal/handler/api_test.go
@@ -1,4 +1,4 @@
-package api
+package handler
 
 import (
 	"net/http"
@@ -7,6 +7,8 @@ import (
 )
 
 func TestPathToReceiver(t *testing.T) {
+	namespace := "go.micro.api"
+
 	testData := []struct {
 		path    string
 		service string
@@ -14,48 +16,48 @@ func TestPathToReceiver(t *testing.T) {
 	}{
 		{
 			"/foo/bar",
-			Namespace + ".foo",
+			namespace + ".foo",
 			"Foo.Bar",
 		},
 		{
 			"/foo/foo/bar",
-			Namespace + ".foo",
+			namespace + ".foo",
 			"Foo.Bar",
 		},
 		{
 			"/foo/bar/baz",
-			Namespace + ".foo",
+			namespace + ".foo",
 			"Bar.Baz",
 		},
 		{
 			"/foo/bar/baz/cat",
-			Namespace + ".foo.bar",
+			namespace + ".foo.bar",
 			"Baz.Cat",
 		},
 		{
 			"/foo/bar/baz/cat/car",
-			Namespace + ".foo.bar.baz",
+			namespace + ".foo.bar.baz",
 			"Cat.Car",
 		},
 		{
 			"/v1/foo/bar",
-			Namespace + ".v1.foo",
+			namespace + ".v1.foo",
 			"Foo.Bar",
 		},
 		{
 			"/v1/foo/bar/baz",
-			Namespace + ".v1.foo",
+			namespace + ".v1.foo",
 			"Bar.Baz",
 		},
 		{
 			"/v1/foo/bar/baz/cat",
-			Namespace + ".v1.foo.bar",
+			namespace + ".v1.foo.bar",
 			"Baz.Cat",
 		},
 	}
 
 	for _, d := range testData {
-		s, m := pathToReceiver(d.path)
+		s, m := pathToReceiver(namespace, d.path)
 		if d.service != s {
 			t.Fatalf("Expected service: %s for path: %s got: %s", d.service, d.path, s)
 		}

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -22,10 +22,6 @@ type proxy struct {
 	ws bool
 }
 
-var (
-	versionRe = regexp.MustCompilePOSIX("^v[0-9]+$")
-)
-
 func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	service, err := p.getService(r)
 	if err != nil {

--- a/internal/handler/rpcx.go
+++ b/internal/handler/rpcx.go
@@ -1,0 +1,134 @@
+package handler
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/micro/go-micro/cmd"
+	"github.com/micro/go-micro/errors"
+	proto "github.com/micro/micro/internal/handler/proto"
+	"github.com/micro/micro/internal/helper"
+)
+
+type rpcxHandler struct {
+	Namespace string
+}
+
+// RPCX Handler is an alternative handler which passes through an RPC request without modification
+func (h *rpcxHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	defer r.Body.Close()
+
+	// get service/method
+	service, method := pathToReceiver(h.Namespace, r.URL.Path)
+	ct := r.Header.Get("Content-Type")
+
+	// Strip charset from Content-Type (like `application/json; charset=UTF-8`)
+	if idx := strings.IndexRune(ct, ';'); idx >= 0 {
+		ct = ct[:idx]
+	}
+
+	switch ct {
+	case "application/json":
+		// response content type
+		w.Header().Set("Content-Type", "application/json")
+
+		// get request
+		br, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			e := errors.InternalServerError("go.micro.api", err.Error())
+			http.Error(w, e.Error(), 500)
+			return
+		}
+		// use as raw json
+		request := json.RawMessage(br)
+
+		// create request/response
+		var response json.RawMessage
+		req := (*cmd.DefaultOptions().Client).NewJsonRequest(service, method, &request)
+
+		// create context
+		ctx := helper.RequestToContext(r)
+
+		// make the call
+		if err := (*cmd.DefaultOptions().Client).Call(ctx, req, &response); err != nil {
+			ce := errors.Parse(err.Error())
+			switch ce.Code {
+			case 0:
+				// assuming it's totally screwed
+				ce.Code = 500
+				ce.Id = "go.micro.api"
+				ce.Status = http.StatusText(500)
+				ce.Detail = "error during request: " + ce.Detail
+				w.WriteHeader(500)
+			default:
+				w.WriteHeader(int(ce.Code))
+			}
+			w.Write([]byte(ce.Error()))
+			return
+		}
+
+		b, _ := response.MarshalJSON()
+		w.Header().Set("Content-Length", strconv.Itoa(len(b)))
+		w.Write(b)
+	case "application/proto", "application/protobuf":
+		// get request
+		br, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			e := errors.InternalServerError("go.micro.api", err.Error())
+			http.Error(w, e.Error(), 500)
+			return
+		}
+
+		// use as raw proto
+		request := proto.NewMessage(br)
+
+		// create request/response
+		response := &proto.Message{}
+		req := (*cmd.DefaultOptions().Client).NewProtoRequest(service, method, request)
+
+		// create context
+		ctx := helper.RequestToContext(r)
+
+		// make the call
+		if err := (*cmd.DefaultOptions().Client).Call(ctx, req, response); err != nil {
+			ce := errors.Parse(err.Error())
+			switch ce.Code {
+			case 0:
+				// assuming it's totally screwed
+				ce.Code = 500
+				ce.Id = "go.micro.api"
+				ce.Status = http.StatusText(500)
+				ce.Detail = "error during request: " + ce.Detail
+				w.WriteHeader(500)
+			default:
+				w.WriteHeader(int(ce.Code))
+			}
+
+			// response content type
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(ce.Error()))
+			return
+		}
+
+		b, _ := response.Marshal()
+		w.Header().Set("Content-Type", r.Header.Get("Content-Type"))
+		w.Header().Set("Content-Length", strconv.Itoa(len(b)))
+		w.Write(b)
+	default:
+		http.Error(w, "unknown content-type", 500)
+		return
+	}
+}
+
+func RPCX(namespace string) http.Handler {
+	return &rpcxHandler{
+		Namespace: namespace,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -77,6 +77,11 @@ func setup(app *ccli.App) {
 			EnvVar: "MICRO_API_NAMESPACE",
 		},
 		ccli.StringFlag{
+			Name:   "sidecar_namespace",
+			Usage:  "Set the namespace used by the Sidecar e.g. com.example.srv",
+			EnvVar: "MICRO_SIDECAR_NAMESPACE",
+		},
+		ccli.StringFlag{
 			Name:   "web_namespace",
 			Usage:  "Set the namespace used by the Web proxy e.g. com.example.web",
 			EnvVar: "MICRO_WEB_NAMESPACE",
@@ -132,6 +137,9 @@ func setup(app *ccli.App) {
 		}
 		if len(ctx.String("api_namespace")) > 0 {
 			api.Namespace = ctx.String("api_namespace")
+		}
+		if len(ctx.String("sidecar_namespace")) > 0 {
+			car.Namespace = ctx.String("sidecar_namespace")
 		}
 		if len(ctx.String("web_namespace")) > 0 {
 			web.Namespace = ctx.String("web_namespace")


### PR DESCRIPTION
This introduces the "rpc" handler used in the API as the default root handler for the sidecar. 