### PR TITLE
Ensure missing dependencies are installed via go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Read the [Getting Started](https://micro.mu/docs/writing-a-go-service.html) guid
 ### Install Micro
 
 ```shell
-go get github.com/micro/micro
+go get -u github.com/micro/micro
 ```
 
 Or via Docker


### PR DESCRIPTION
Without `-u` flag when running a clean install, `github.com/golang/protobuf` is not installed:

```
$ go get github.com/micro/micro
# github.com/micro/micro/bot/proto
bot/proto/bot.pb.go:220: undefined: proto.RegisterFile
```