### PR TITLE
Added health check endpoint flag

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -107,6 +107,23 @@ func run(ctx *cli.Context) {
 		defer st.Stop()
 	}
 
+	if len(ctx.String("health_endpoint")) > 0 {
+		he := ctx.String("health_endpoint")
+		var healthEndpoint string
+		if he[0:1] == "/" {
+			healthEndpoint = he
+		} else {
+			healthEndpoint = "/" + he
+		}
+		log.Logf("Registering health check endpoint at %s", healthEndpoint)
+
+		r.HandleFunc(healthEndpoint, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("content-type", "text/html")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("<h1>&#128077;</h1>"))
+		})
+	}
+
 	log.Logf("Registering RPC Handler at %s", RPCPath)
 	r.HandleFunc(RPCPath, handler.RPC)
 
@@ -191,6 +208,11 @@ func Commands() []cli.Command {
 				Name:   "cors",
 				Usage:  "Comma separated whitelist of allowed origins for CORS",
 				EnvVar: "MICRO_API_CORS",
+			},
+			cli.StringFlag{
+				Name:   "health_endpoint",
+				Usage:  "Specify the endpoint that can be used for health checks; e.g. /health",
+				EnvVar: "MICRO_API_HEALTH_ENDPOINT",
 			},
 		},
 	}


### PR DESCRIPTION
This PR adds a new flag to Micro API called `health_endpoint` which can used to configure a simple HTTP endpoint that can be used by load balancers (in my case AWS Application Load Balancer) to confirm availability.

Usage:

1. `micro api --health_endpoint=/health`
1. Visit `:8080/health` (or whatever you've configured to be the endpoint) and you can expect a HTTP 200 response

This is my first ever PR for a Golang project, please do let me know if my code can be improved in any way 👍 