### PR TITLE
Enable acme support

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -66,6 +66,20 @@ go get github.com/micro/micro
 micro api
 ```
 
+### ACME via Let's Encrypt
+
+Serve securely by default using ACME via letsencrypt
+
+```
+micro --enable_acme api
+```
+
+Optionally specify a host whitelist
+
+```
+micro --enable_acme --acme_hosts=example.com,api.example.com api
+```
+
 ### Serve Secure TLS
 
 The API supports serving securely with TLS certificates

--- a/api/api.go
+++ b/api/api.go
@@ -83,7 +83,11 @@ func run(ctx *cli.Context) {
 	// Init API
 	var opts []server.Option
 
-	if ctx.GlobalBool("enable_tls") {
+	if ctx.GlobalBool("enable_acme") {
+		hosts := strings.Split(ctx.String("acme_hosts"), ",")
+		opts = append(opts, server.EnableACME(true))
+		opts = append(opts, server.ACMEHosts(hosts...))
+	} else if ctx.GlobalBool("enable_tls") {
 		config, err := helper.TLSConfig(ctx)
 		if err != nil {
 			fmt.Println(err.Error())

--- a/api/api.go
+++ b/api/api.go
@@ -84,7 +84,7 @@ func run(ctx *cli.Context) {
 	var opts []server.Option
 
 	if ctx.GlobalBool("enable_acme") {
-		hosts := strings.Split(ctx.String("acme_hosts"), ",")
+		hosts := helper.ACMEHosts(ctx)
 		opts = append(opts, server.EnableACME(true))
 		opts = append(opts, server.ACMEHosts(hosts...))
 	} else if ctx.GlobalBool("enable_tls") {

--- a/car/README.md
+++ b/car/README.md
@@ -69,6 +69,20 @@ Optionally specify app server name and address if you want to auto register an a
 micro sidecar --server_name=foo --server_address=127.0.0.1:9090
 ```
 
+### ACME via Let's Encrypt
+
+Serve securely by default using ACME via letsencrypt 
+
+```
+micro --enable_acme api
+```
+
+Optionally specify a host whitelist
+
+```
+micro --enable_acme --acme_hosts=example.com,api.example.com api
+```
+
 ### Serve Secure TLS
 
 The Sidecar supports serving securely with TLS certificates

--- a/car/car.go
+++ b/car/car.go
@@ -103,7 +103,7 @@ func run(ctx *cli.Context, car *sidecar) {
 	var opts []server.Option
 
 	if ctx.GlobalBool("enable_acme") {
-		hosts := strings.Split(ctx.String("acme_hosts"), ",")
+		hosts := helper.ACMEHosts(ctx)
 		opts = append(opts, server.EnableACME(true))
 		opts = append(opts, server.ACMEHosts(hosts...))
 	} else if ctx.GlobalBool("enable_tls") {

--- a/car/car.go
+++ b/car/car.go
@@ -102,7 +102,11 @@ func run(ctx *cli.Context, car *sidecar) {
 
 	var opts []server.Option
 
-	if ctx.GlobalBool("enable_tls") {
+	if ctx.GlobalBool("enable_acme") {
+		hosts := strings.Split(ctx.String("acme_hosts"), ",")
+		opts = append(opts, server.EnableACME(true))
+		opts = append(opts, server.ACMEHosts(hosts...))
+	} else if ctx.GlobalBool("enable_tls") {
 		config, err := helper.TLSConfig(ctx)
 		if err != nil {
 			fmt.Println(err.Error())

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -24,23 +24,33 @@ var (
 func setup(app *ccli.App) {
 	app.Flags = append(app.Flags,
 		ccli.BoolFlag{
+			Name:   "enable_acme",
+			Usage:  "Enables ACME support via Let's Encrypt. ACME hosts should also be specified.",
+			EnvVar: "MICRO_ENABLE_ACME",
+		},
+		ccli.StringFlag{
+			Name:   "acme_hosts",
+			Usage:  "Comma separated list of hostnames to manage ACME certs for",
+			EnvVar: "MICRO_ACME_HOSTS",
+		},
+		ccli.BoolFlag{
 			Name:   "enable_tls",
-			Usage:  "Enable TLS",
+			Usage:  "Enable TLS support. Expects cert and key file to be specified",
 			EnvVar: "MICRO_ENABLE_TLS",
 		},
 		ccli.StringFlag{
 			Name:   "tls_cert_file",
-			Usage:  "TLS Certificate file",
+			Usage:  "Path to the TLS Certificate file",
 			EnvVar: "MICRO_TLS_CERT_FILE",
 		},
 		ccli.StringFlag{
 			Name:   "tls_key_file",
-			Usage:  "TLS Key file",
+			Usage:  "Path to the TLS Key file",
 			EnvVar: "MICRO_TLS_KEY_FILE",
 		},
 		ccli.StringFlag{
 			Name:   "tls_client_ca_file",
-			Usage:  "TLS CA file to verify clients against",
+			Usage:  "Path to the TLS CA file to verify clients against",
 			EnvVar: "MICRO_TLS_CLIENT_CA_FILE",
 		},
 		ccli.StringFlag{

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -14,6 +14,16 @@ import (
 	"golang.org/x/net/context"
 )
 
+func ACMEHosts(ctx *cli.Context) []string {
+	var hosts []string
+	for _, host := range strings.Split(ctx.String("acme_hosts"), ",") {
+		if len(host) > 0 {
+			hosts = append(hosts, host)
+		}
+	}
+	return hosts
+}
+
 func RequestToContext(r *http.Request) context.Context {
 	ctx := context.Background()
 	md := make(metadata.Metadata)

--- a/internal/server/options.go
+++ b/internal/server/options.go
@@ -7,8 +7,22 @@ import (
 type Option func(o *Options)
 
 type Options struct {
-	EnableTLS bool
-	TLSConfig *tls.Config
+	EnableACME bool
+	EnableTLS  bool
+	ACMEHosts  []string
+	TLSConfig  *tls.Config
+}
+
+func ACMEHosts(hosts ...string) Option {
+	return func(o *Options) {
+		o.ACMEHosts = hosts
+	}
+}
+
+func EnableACME(b bool) Option {
+	return func(o *Options) {
+		o.EnableACME = b
+	}
 }
 
 func EnableTLS(b bool) Option {

--- a/web/README.md
+++ b/web/README.md
@@ -56,6 +56,20 @@ micro web
 ```
 Browse to localhost:8082
 
+### ACME via Let's Encrypt
+
+Serve securely by default using ACME via letsencrypt 
+
+```
+micro --enable_acme api
+```
+
+Optionally specify a host whitelist
+
+```
+micro --enable_acme --acme_hosts=example.com,api.example.com api
+```
+
 ### Serve Secure TLS
 
 The Web proxy supports serving securely with TLS certificates

--- a/web/web.go
+++ b/web/web.go
@@ -356,7 +356,11 @@ func run(ctx *cli.Context) {
 
 	var opts []server.Option
 
-	if ctx.GlobalBool("enable_tls") {
+	if ctx.GlobalBool("enable_acme") {
+		hosts := strings.Split(ctx.String("acme_hosts"), ",")
+		opts = append(opts, server.EnableACME(true))
+		opts = append(opts, server.ACMEHosts(hosts...))
+	} else if ctx.GlobalBool("enable_tls") {
 		config, err := helper.TLSConfig(ctx)
 		if err != nil {
 			fmt.Println(err.Error())

--- a/web/web.go
+++ b/web/web.go
@@ -357,7 +357,7 @@ func run(ctx *cli.Context) {
 	var opts []server.Option
 
 	if ctx.GlobalBool("enable_acme") {
-		hosts := strings.Split(ctx.String("acme_hosts"), ",")
+		hosts := helper.ACMEHosts(ctx)
 		opts = append(opts, server.EnableACME(true))
 		opts = append(opts, server.ACMEHosts(hosts...))
 	} else if ctx.GlobalBool("enable_tls") {


### PR DESCRIPTION
This PR enables ACME support via let's encrypt and the autocert library.

It's very simple. Use the `--enable_acme` flag to enable acme. This ignores the server address and binds to port 443 since this is the requirement of acme. Use `--acme_hosts` to specify a comma separated hosts to whitelist. That's it.