### PR TITLE
Add event handler

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -55,7 +55,11 @@ The API has three types of configurable request handlers.
 	- Request/Response: http
 	- The request will be reverse proxied to the service resolved by the first element in the path
 	- This allows REST to be implemented behind the API
-	- Set via `--handler=proxy`.
+	- Set via `--handler=proxy`
+4. Event Handler: /[topic]/[event]
+	- Async handler publishes request to message broker as an event
+	- Request is formatted as [go-api/proto.Event](https://github.com/micro/go-api/blob/master/proto/api.proto#L28L39)
+	- Set via `--handler=event`
 
 Alternatively use the /rpc endpoint to speak to any service directly
 - Expects params: `service`, `method`, `request`, optionally accepts `address` to target a specific host

--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,8 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/micro/cli"
 	"github.com/micro/go-api"
+	ahandler "github.com/micro/go-api/handler"
+	"github.com/micro/go-api/handler/event"
 	"github.com/micro/go-api/router"
 	"github.com/micro/go-api/server"
 	"github.com/micro/go-log"
@@ -127,6 +129,11 @@ func run(ctx *cli.Context) {
 		log.Logf("Registering API Request Handler at %s", APIPath)
 		rt := router.NewRouter(router.WithNamespace(Namespace), router.WithHandler(api.Api))
 		r.PathPrefix(APIPath).Handler(handler.API(rt, nil))
+	case "event":
+		log.Logf("Registering API Event Handler at %s", APIPath)
+		rt := router.NewRouter(router.WithNamespace(Namespace), router.WithHandler(api.Event))
+		ev := event.NewHandler(ahandler.WithNamespace(Namespace), ahandler.WithRouter(rt))
+		r.PathPrefix(APIPath).Handler(ev)
 	default:
 		log.Logf("Registering API Default Handler at %s", APIPath)
 		r.PathPrefix(APIPath).Handler(handler.Meta(Namespace))

--- a/internal/handler/meta.go
+++ b/internal/handler/meta.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"github.com/micro/go-api"
+	"github.com/micro/go-api/handler"
+	"github.com/micro/go-api/handler/event"
 	"github.com/micro/go-api/router"
 	"github.com/micro/go-micro/errors"
 )
@@ -29,6 +31,12 @@ func (m *metaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// rpcx handler
 	case api.Rpc:
 		RPCX(nil, service).ServeHTTP(w, r)
+	// event handler
+	case api.Event:
+		ev := event.NewHandler(
+			handler.WithNamespace(m.r.Options().Namespace),
+		)
+		ev.ServeHTTP(w, r)
 	// api handler
 	case api.Api:
 		API(nil, service).ServeHTTP(w, r)


### PR DESCRIPTION
The event handler is an async publishing handler for the micro api. An message can be published to the micro api which is then formatted as an [event](https://github.com/micro/go-api/blob/master/proto/api.proto#L28L39) and published on the go-micro message broker.

Event format 

```
// A HTTP event as RPC
message Event {
	// e.g login
	string name = 1;
	// uuid
	string id = 2;
	// unix timestamp of event
	int64 timestamp = 3;
	// event headers
        map<string, Pair> header = 4;
	// the event data
	string data = 5;
}
```

Publishing an event is as simple as doing

```
curl -d '{"foo": "bar"}' http://micro.api/topic/event
```

The micro api uses the namespace plus first part in the path to determine topic. Anything afterwards is used as part of the event name.

Example

Run micro api with namespace go.micro.evt

```
micro --handler=event --namespace=go.micro.evt
```

Publish event `login` to `go.micro.evt.user` topic

```
curl -d '{"name": "john"}' http://micro.api/user/login
```

The event can be picked up on the other side by a micro service

```
package main

import (
	proto "github.com/micro/go-api/proto"
	"github.com/micro/go-log"
	"github.com/micro/go-micro"

	"golang.org/x/net/context"
)

type Event struct{}

// Method can be any name
func (e *Event) Process(ctx context.Context, event *proto.Event) error {
	log.Logf("Received event %+v\n", event)
	return nil
}

func main() {
	service := micro.NewService(
		micro.Name("user"),
	)
	service.Init()

	// register subscriber
	micro.RegisterSubscriber("go.micro.evt.user", service.Server(), new(Event))

	if err := service.Run(); err != nil {
		log.Fatal(err)
	}
}
```