### PR TITLE
api: api proxy can allow websocket forwarding

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -23,15 +23,16 @@ import (
 )
 
 var (
-	Name         = "go.micro.api"
-	Address      = ":8080"
-	Handler      = string(api.Default)
-	RPCPath      = "/rpc"
-	APIPath      = "/"
-	ProxyPath    = "/{service:[a-zA-Z0-9]+}"
-	Namespace    = "go.micro.api"
-	HeaderPrefix = "X-Micro-"
-	CORS         = map[string]bool{"*": true}
+	Name           = "go.micro.api"
+	Address        = ":8080"
+	Handler        = string(api.Default)
+	RPCPath        = "/rpc"
+	APIPath        = "/"
+	ProxyPath      = "/{service:[a-zA-Z0-9]+}"
+	Namespace      = "go.micro.api"
+	HeaderPrefix   = "X-Micro-"
+	CORS           = map[string]bool{"*": true}
+	AllowWebsocket = false
 )
 
 type srv struct {
@@ -68,6 +69,9 @@ func run(ctx *cli.Context) {
 	}
 	if len(ctx.String("namespace")) > 0 {
 		Namespace = ctx.String("namespace")
+	}
+	if len(ctx.String("allow_websocket")) > 0 {
+		AllowWebsocket = ctx.Bool("allow_websocket")
 	}
 	if len(ctx.String("cors")) > 0 {
 		origins := make(map[string]bool)
@@ -124,7 +128,7 @@ func run(ctx *cli.Context) {
 	case "proxy":
 		log.Logf("Registering API Proxy Handler at %s", ProxyPath)
 		rt := router.NewRouter(router.WithNamespace(Namespace), router.WithHandler(api.Proxy))
-		r.PathPrefix(ProxyPath).Handler(handler.Proxy(rt, nil, false))
+		r.PathPrefix(ProxyPath).Handler(handler.Proxy(rt, nil, AllowWebsocket))
 	case "api":
 		log.Logf("Registering API Request Handler at %s", APIPath)
 		rt := router.NewRouter(router.WithNamespace(Namespace), router.WithHandler(api.Api))
@@ -202,6 +206,11 @@ func Commands() []cli.Command {
 				Name:   "cors",
 				Usage:  "Comma separated whitelist of allowed origins for CORS",
 				EnvVar: "MICRO_API_CORS",
+			},
+			cli.StringFlag{
+				Name:   "allow_websocket",
+				Usage:  "Allow websocket forwarding to services",
+				EnvVar: "MICRO_API_WEBSOCKET",
 			},
 		},
 	}

--- a/internal/handler/proxy.go
+++ b/internal/handler/proxy.go
@@ -38,6 +38,7 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	service = "http://" + service
 	rp, err := url.Parse(service)
 	if err != nil {
 		w.WriteHeader(500)
@@ -75,7 +76,7 @@ func (p *proxy) getService(r *http.Request) (string, error) {
 		return "", nil
 	}
 
-	return fmt.Sprintf("http://%s:%d", s.Address, s.Port), nil
+	return fmt.Sprintf("%s:%d", s.Address, s.Port), nil
 }
 
 // serveWebSocket used to serve a web socket proxied connection


### PR DESCRIPTION
Now, micro api gateway does not accept websocket from client to services.
I have added a new option "--allow_websocket" to forward external websockets to services websockets.
I think it is more simple to have these api option otherwise registering a home made plugin which does the job.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/micro/micro/132)
<!-- Reviewable:end -->
