### PR TITLE
Patching internal server error to use the namespace specified at runtime

### DIFF
--- a/internal/handler/meta.go
+++ b/internal/handler/meta.go
@@ -23,7 +23,7 @@ type metaHandler struct {
 func (m *metaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	service, err := m.r.Route(r)
 	if err != nil {
-		er := errors.InternalServerError("go.micro.api", err.Error())
+		er := errors.InternalServerError(m.r.Options().Namespace, err.Error())
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(500)
 		w.Write([]byte(er.Error()))


### PR DESCRIPTION
I wasn't able to find any other occurrences. 