### PR TITLE
add ability to set plugins for micro new command

### DIFF
--- a/internal/template/makefile.go
+++ b/internal/template/makefile.go
@@ -14,8 +14,8 @@ build: proto
 {{else}}
 build:
 {{end}}
-	go build -o {{.Alias}}-{{.Type}} main.go
-    
+	go build -o {{.Alias}}-{{.Type}} main.go plugin.go
+   
 test:
 	go test -v ./... -cover
 

--- a/internal/template/makefile.go
+++ b/internal/template/makefile.go
@@ -15,7 +15,7 @@ build: proto
 build:
 {{end}}
 	go build -o {{.Alias}}-{{.Type}} main.go plugin.go
-   
+
 test:
 	go test -v ./... -cover
 

--- a/internal/template/plugin.go
+++ b/internal/template/plugin.go
@@ -1,0 +1,10 @@
+package template
+
+var (
+	Plugin = `package main
+{{if .Plugins}}
+import ({{range .Plugins}}
+	_ "github.com/micro/go-plugins/{{.}}"{{end}}
+){{end}}
+`
+)

--- a/internal/template/readme.go
+++ b/internal/template/readme.go
@@ -1,84 +1,121 @@
 package template
 
 var (
-	Readme = `# {{title .Alias}} {{title .Type}}
+	Readme = `# {{title .Alias}} Service
 
-This is the {{title .Alias}} service with fqdn {{.FQDN}}.
+This is the {{title .Alias}} service
+
+Generated with
+
+` + "```" +
+		`
+{{.Command}}
+` + "```" + `
 
 ## Getting Started
 
-### Prerequisites
+- [Configuration](#configuration)
+- [Dependencies](#dependencies)
+- [Usage](#usage)
 
-Install Consul
-[https://www.consul.io/intro/getting-started/install.html](https://www.consul.io/intro/getting-started/install.html)
+## Configuration
 
-Run Consul
+- FQDN: {{.FQDN}}
+- Type: {{.Type}}
+- Alias: {{.Alias}}
+
+## Dependencies
+
+Micro services depend on service discovery. The default is consul.
+
 ` + "```" +
 		`
-$ consul agent -dev -advertise=127.0.0.1
+# install consul
+brew install consul
+
+# run consul
+consul agent -dev
+` + "```" + `
+
+## Usage
+
+A Makefile is included for convenience
+
+Build the binary
+
 ` + "```" +
 		`
+make build
+` + "```" + `
 
-### Run Service
-
+Run the service
 ` + "```" +
 		`
-$ go run main.go
+./{{.Alias}}-{{.Type}}
+` + "```" + `
+
+Build a docker image
 ` + "```" +
 		`
-
-### Building a container
-
-If you would like to build the docker container do the following
-` + "```" +
-		`
-CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' -o {{.Alias}}-{{.Type}} ./main.go
-docker build -t {{.Alias}}-{{.Type}} .
-
+make docker
 ` + "```"
 
-	ReadmeFNC = `# {{title .Alias}} {{title .Type}}
+	ReadmeFNC = `# {{title .Alias}} Function
 
-This is the {{title .Alias}} function with fqdn {{.FQDN}}.
+This is the {{title .Alias}} function
+
+Generated with
+
+` + "```" +
+		`
+{{.Command}}
+` + "```" + `
 
 ## Getting Started
 
-### Service Discovery
+- [Configuration](#configuration)
+- [Dependencies](#dependencies)
+- [Usage](#usage)
 
-Install Consul
-[https://www.consul.io/intro/getting-started/install.html](https://www.consul.io/intro/getting-started/install.html)
+## Configuration
 
-Run Consul
-` + "```" +
-		`
-$ consul agent -dev
-` + "```" +
-		`
-### Micro Toolkit
+- FQDN: {{.FQDN}}
+- Type: {{.Type}}
+- Alias: {{.Alias}}
 
-Install Micro
+## Dependencies
 
-` + "```" +
-		`
-go get github.com/micro/micro
-` + "```" +
-		`
-
-### Run Function
+Micro functions depend on service discovery. The default is consul.
 
 ` + "```" +
 		`
-$ micro run -r {{.Dir}}
+# install consul
+brew install consul
+
+# run consul
+consul agent -dev
+` + "```" + `
+
+## Usage
+
+A Makefile is included for convenience
+
+Build the binary
+
 ` + "```" +
 		`
+make build
+` + "```" + `
 
-### Building a container
-
-If you would like to build the docker container do the following
+Run the function once
 ` + "```" +
 		`
-CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' -o {{.Alias}}-{{.Type}} ./main.go
-docker build -t {{.Alias}}-{{.Type}} .
+./{{.Alias}}-{{.Type}}
+` + "```" + `
 
+Build a docker image
+` + "```" +
+		`
+make docker
 ` + "```"
 )

--- a/new/README.md
+++ b/new/README.md
@@ -49,18 +49,29 @@ Specify more options such as namespace, type, fqdn and alias
 micro new --fqdn io.foobar.srv.example github.com/micro/example
 ```
 
+## Plugins
+
+Specify micro plugins at time of creation.
+
+These must still be flagged on the command line when using the app.
+
+```
+micro new example --plugin=registry=etcd:broker=nats
+```
+
 ### Help
 
 ```
 NAME:
-   micro new - Create a new micro service
+   micro new - Create a new micro service by specifying a directory path relative to your $GOPATH
 
 USAGE:
    micro new [command options] [arguments...]
 
 OPTIONS:
-   --namespace "go.micro"	Namespace for the service e.g com.example
-   --type "srv"			Type of service e.g api, srv, web
-   --fqdn 			FQDN of service e.g com.example.srv.service (defaults to namespace.type.alias)
-   --alias 			Alias is the short name used as part of combined name if specified
+   --namespace "go.micro"			Namespace for the service e.g com.example
+   --type "srv"					Type of service e.g api, fnc, srv, web
+   --fqdn 					FQDN of service e.g com.example.srv.service (defaults to namespace.type.alias)
+   --alias 					Alias is the short name used as part of combined name if specified
+   --plugin [--plugin option --plugin option]	Specify plugins e.g --plugin=registry=etcd:broker=nats or use flag multiple times
 ```

--- a/new/new.go
+++ b/new/new.go
@@ -18,6 +18,8 @@ import (
 type config struct {
 	// foo
 	Alias string
+	// micro new example -type
+	Command string
 	// go.micro
 	Namespace string
 	// api, srv, web, fnc
@@ -34,7 +36,7 @@ type config struct {
 	Files []file
 	// Comments
 	Comments []string
-	// Plugins
+	// Plugins registry=etcd:broker=nats
 	Plugins []string
 }
 
@@ -134,6 +136,24 @@ func run(ctx *cli.Context) {
 		return
 	}
 
+	// set the command
+	command := fmt.Sprintf("micro new %s", dir)
+	if len(namespace) > 0 {
+		command += " --namespace=" + namespace
+	}
+	if len(alias) > 0 {
+		command += " --alias=" + alias
+	}
+	if len(fqdn) > 0 {
+		command += " --fqdn=" + fqdn
+	}
+	if len(atype) > 0 {
+		command += " --type=" + atype
+	}
+	if plugins := ctx.StringSlice("plugin"); len(plugins) > 0 {
+		command += " --plugin=" + strings.Join(plugins, ":")
+	}
+
 	// check if the path is absolute, we don't want this
 	// we want to a relative path so we can install in GOPATH
 	if path.IsAbs(dir) {
@@ -184,6 +204,7 @@ func run(ctx *cli.Context) {
 		// create srv config
 		c = config{
 			Alias:     alias,
+			Command:   command,
 			Namespace: namespace,
 			Type:      atype,
 			FQDN:      fqdn,
@@ -215,6 +236,7 @@ func run(ctx *cli.Context) {
 		// create srv config
 		c = config{
 			Alias:     alias,
+			Command:   command,
 			Namespace: namespace,
 			Type:      atype,
 			FQDN:      fqdn,
@@ -246,6 +268,7 @@ func run(ctx *cli.Context) {
 		// create api config
 		c = config{
 			Alias:     alias,
+			Command:   command,
 			Namespace: namespace,
 			Type:      atype,
 			FQDN:      fqdn,
@@ -277,6 +300,7 @@ func run(ctx *cli.Context) {
 		// create srv config
 		c = config{
 			Alias:     alias,
+			Command:   command,
 			Namespace: namespace,
 			Type:      atype,
 			FQDN:      fqdn,


### PR DESCRIPTION
This PR adds the ability to specify plugins at time of generating a template. It creates a separate plugin.go file as part of the main package which includes the imports as part of micro's best practice pattern. 

Plugins are specified as so

```
micro new github.com/micro/example --plugin=registry=etcd:broker=nats 
```