### PR TITLE
MICRO_NAMESPACE now MICRO_API_NAMESPACE in micro/api

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -69,7 +69,7 @@ The API makes use of namespaces to logically separate backend and public facing 
 are used to resolve service name/method. The default namespace is `go.micro.api`.
 
 ```shell
-MICRO_NAMESPACE=com.example.api micro api
+MICRO_API_NAMESPACE=com.example.api micro api
 ```
 
 ## Examples
@@ -248,7 +248,7 @@ Find working examples in [github.com/micro/examples/api](https://github.com/micr
 
 Micro dynamically routes to services using a namespace value and the HTTP path.
 
-The default namespace is `go.micro.api`. Set namespace via `--namespace` or `MICRO_NAMESPACE=`.
+The default namespace is `go.micro.api`. Set namespace via `--namespace` or `MICRO_API_NAMESPACE=`.
 
 The resolvers used are explained below.
 


### PR DESCRIPTION
Please correct me if I'm wrong, but the api/README.md didn't work for me with MICRO_NAMESPACE env, so I looked up how the Stringflags were read, and it looked like a mistake.

So, this PR just updates the README.md.