### PR TITLE
Switch default handler to rpc

### DIFF
--- a/internal/handler/meta.go
+++ b/internal/handler/meta.go
@@ -49,9 +49,9 @@ func (m *metaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// api handler
 	case aapi.Handler:
 		aapi.WithService(service).ServeHTTP(w, r)
-	// default handler: api
+	// default handler: rpc
 	default:
-		aapi.WithService(service).ServeHTTP(w, r)
+		arpc.WithService(service).ServeHTTP(w, r)
 	}
 }
 


### PR DESCRIPTION
It's become clear over the past few years that people want the default handler to be RPC. The reason is that they don't need the full http request values when writing an api service. In fact most don't want an api tier of services. It's useful where you have a complex architecture but more don't start this way.