### PR TITLE
Upgrade jquery.terminal to 2.0.2

### DIFF
--- a/web/templates.go
+++ b/web/templates.go
@@ -297,14 +297,14 @@ jQuery(function($, undefined) {
 
 	cliTemplate = `
 {{define "head"}}
-<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/0.9.3/css/jquery.terminal.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.0.2/css/jquery.terminal.min.css">
 {{end}}
 {{define "title"}}CLI{{end}}
 {{define "content"}}
 <div id="shell"></div>
 {{end}}
 {{define "script"}}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/0.9.3/js/jquery.terminal.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.0.2/js/jquery.terminal.min.js"></script>
 <script type="text/javascript">
 jQuery(function($, undefined) {
     $('#shell').terminal(function(command, term) {


### PR DESCRIPTION
## Issue

```
curl -i https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/0.9.3/css/jquery.terminal.min.css
HTTP/1.1 404 Not Found
Date: Thu, 27 Dec 2018 04:52:13 GMT
Content-Type: text/html
Transfer-Encoding: chunked
Connection: keep-alive
Served-In-Seconds: 0.000
CF-Cache-Status: EXPIRED
Expires: Thu, 27 Dec 2018 08:52:13 GMT
Cache-Control: public, max-age=14400
Strict-Transport-Security: max-age=15780000; includeSubDomains
Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
Server: cloudflare
CF-RAY: 48f92d325c437aee-MCI
```

## Suggested solution

```
curl -i https://cdnjs.cloudflare.com/ajax/libs/jquery.terminal/2.0.2/js/jquery.terminal.min.js
HTTP/1.1 200 OK
Date: Thu, 27 Dec 2018 04:53:06 GMT
Content-Type: application/javascript
Transfer-Encoding: chunked
Connection: keep-alive
Last-Modified: Sat, 22 Dec 2018 15:30:52 GMT
ETag: W/"5c1e58ac-1ca9a"
Expires: Tue, 17 Dec 2019 04:53:06 GMT
Cache-Control: public, max-age=30672000
Access-Control-Allow-Origin: *
Served-In-Seconds: 0.003
CF-Cache-Status: HIT
Strict-Transport-Security: max-age=15780000; includeSubDomains
Expect-CT: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
Server: cloudflare
CF-RAY: 48f92e787db37afa-MCI
```