### PR TITLE
Customize templates

### DIFF
--- a/internal/template/handler.go
+++ b/internal/template/handler.go
@@ -6,13 +6,13 @@ var (
 import (
 	"context"
 
-	example "{{.Dir}}/proto/example"
+	{{.Alias}} "{{.Dir}}/proto/{{.Alias}}"
 )
 
-type Example struct{}
+type {{title .Alias}} struct{}
 
 // Call is a single request handler called via client.Call or the generated client code
-func (e *Example) Call(ctx context.Context, req *example.Request, rsp *example.Response) error {
+func (e *{{title .Alias}}) Call(ctx context.Context, req *{{.Alias}}.Request, rsp *{{.Alias}}.Response) error {
 	rsp.Msg = "Hello " + req.Name
 	return nil
 }
@@ -25,25 +25,25 @@ import (
 
 	"github.com/micro/go-log"
 
-	example "{{.Dir}}/proto/example"
+	{{.Alias}} "{{.Dir}}/proto/{{.Alias}}"
 )
 
-type Example struct{}
+type {{title .Alias}} struct{}
 
 // Call is a single request handler called via client.Call or the generated client code
-func (e *Example) Call(ctx context.Context, req *example.Request, rsp *example.Response) error {
-	log.Log("Received Example.Call request")
+func (e *{{title .Alias}}) Call(ctx context.Context, req *{{.Alias}}.Request, rsp *{{.Alias}}.Response) error {
+	log.Log("Received {{title .Alias}}.Call request")
 	rsp.Msg = "Hello " + req.Name
 	return nil
 }
 
 // Stream is a server side stream handler called via client.Stream or the generated client code
-func (e *Example) Stream(ctx context.Context, req *example.StreamingRequest, stream example.Example_StreamStream) error {
-	log.Logf("Received Example.Stream request with count: %d", req.Count)
+func (e *{{title .Alias}}) Stream(ctx context.Context, req *{{.Alias}}.StreamingRequest, stream {{.Alias}}.{{title .Alias}}_StreamStream) error {
+	log.Logf("Received {{title .Alias}}.Stream request with count: %d", req.Count)
 
 	for i := 0; i < int(req.Count); i++ {
 		log.Logf("Responding: %d", i)
-		if err := stream.Send(&example.StreamingResponse{
+		if err := stream.Send(&{{.Alias}}.StreamingResponse{
 			Count: int64(i),
 		}); err != nil {
 			return err
@@ -54,14 +54,14 @@ func (e *Example) Stream(ctx context.Context, req *example.StreamingRequest, str
 }
 
 // PingPong is a bidirectional stream handler called via client.Stream or the generated client code
-func (e *Example) PingPong(ctx context.Context, stream example.Example_PingPongStream) error {
+func (e *{{title .Alias}}) PingPong(ctx context.Context, stream {{.Alias}}.{{title .Alias}}_PingPongStream) error {
 	for {
 		req, err := stream.Recv()
 		if err != nil {
 			return err
 		}
 		log.Logf("Got ping %v", req.Stroke)
-		if err := stream.Send(&example.Pong{Stroke: req.Stroke}); err != nil {
+		if err := stream.Send(&{{.Alias}}.Pong{Stroke: req.Stroke}); err != nil {
 			return err
 		}
 	}
@@ -75,12 +75,12 @@ import (
 
 	"github.com/micro/go-log"
 
-	example "{{.Dir}}/proto/example"
+	{{.Alias}} "{{.Dir}}/proto/{{.Alias}}"
 )
 
-type Example struct{}
+type {{title .Alias}} struct{}
 
-func (e *Example) Handle(ctx context.Context, msg *example.Message) error {
+func (e *{{title .Alias}}) Handle(ctx context.Context, msg *{{.Alias}}.Message) error {
 	log.Log("Handler Received message: ", msg.Say)
 	return nil
 }
@@ -92,17 +92,17 @@ import (
 	"context"
 	"github.com/micro/go-log"
 
-	example "{{.Dir}}/proto/example"
+	{{.Alias}} "{{.Dir}}/proto/{{.Alias}}"
 )
 
-type Example struct{}
+type {{title .Alias}} struct{}
 
-func (e *Example) Handle(ctx context.Context, msg *example.Message) error {
+func (e *{{title .Alias}}) Handle(ctx context.Context, msg *{{.Alias}}.Message) error {
 	log.Log("Handler Received message: ", msg.Say)
 	return nil
 }
 
-func Handler(ctx context.Context, msg *example.Message) error {
+func Handler(ctx context.Context, msg *{{.Alias}}.Message) error {
 	log.Log("Function Received message: ", msg.Say)
 	return nil
 }
@@ -118,10 +118,10 @@ import (
 	"{{.Dir}}/client"
 	"github.com/micro/go-micro/errors"
 	api "github.com/micro/go-api/proto"
-	example "github.com/micro/examples/template/srv/proto/example"
+	{{.Alias}} "path/to/service/proto/{{.Alias}}"
 )
 
-type Example struct{}
+type {{title .Alias}} struct{}
 
 func extractValue(pair *api.Pair) string {
 	if pair == nil {
@@ -133,22 +133,22 @@ func extractValue(pair *api.Pair) string {
 	return pair.Values[0]
 }
 
-// Example.Call is called by the API as /{{.Alias}}/example/call with post body {"name": "foo"}
-func (e *Example) Call(ctx context.Context, req *api.Request, rsp *api.Response) error {
-	log.Log("Received Example.Call request")
+// {{title .Alias}}.Call is called by the API as /{{.Alias}}/call with post body {"name": "foo"}
+func (e *{{title .Alias}}) Call(ctx context.Context, req *api.Request, rsp *api.Response) error {
+	log.Log("Received {{title .Alias}}.Call request")
 
 	// extract the client from the context
-	exampleClient, ok := client.ExampleFromContext(ctx)
+	{{.Alias}}Client, ok := client.{{title .Alias}}FromContext(ctx)
 	if !ok {
-		return errors.InternalServerError("{{.FQDN}}.example.call", "example client not found")
+		return errors.InternalServerError("{{.FQDN}}.{{.Alias}}.call", "{{.Alias}} client not found")
 	}
 
 	// make request
-	response, err := exampleClient.Call(ctx, &example.Request{
+	response, err := {{.Alias}}Client.Call(ctx, &{{.Alias}}.Request{
 		Name: extractValue(req.Post["name"]),
 	})
 	if err != nil {
-		return errors.InternalServerError("{{.FQDN}}.example.call", err.Error())
+		return errors.InternalServerError("{{.FQDN}}.{{.Alias}}.call", err.Error())
 	}
 
 	b, _ := json.Marshal(response)
@@ -169,10 +169,10 @@ import (
 	"time"
 
 	"github.com/micro/go-micro/client"
-	example "github.com/micro/examples/template/srv/proto/example"
+	{{.Alias}} "path/to/service/proto/{{.Alias}}"
 )
 
-func ExampleCall(w http.ResponseWriter, r *http.Request) {
+func {{title .Alias}}Call(w http.ResponseWriter, r *http.Request) {
 	// decode the incoming request as json
 	var request map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
@@ -181,8 +181,8 @@ func ExampleCall(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// call the backend service
-	exampleClient := example.NewExampleService("go.micro.srv.template", client.DefaultClient)
-	rsp, err := exampleClient.Call(context.TODO(), &example.Request{
+	{{.Alias}}Client := {{.Alias}}.New{{title .Alias}}Service("{{.Namespace}}.srv.{{.Alias}}", client.DefaultClient)
+	rsp, err := {{.Alias}}Client.Call(context.TODO(), &{{.Alias}}.Request{
 		Name: request["name"].(string),
 	})
 	if err != nil {

--- a/internal/template/html.go
+++ b/internal/template/html.go
@@ -23,7 +23,7 @@ var (
             <div class="row">
                 <div class="col-md-8">
                     <h1>{{title .Alias}} {{title .Type}}</h1>
-                    <form class="example">
+                    <form class="{{.Alias}}">
                         <div class="form-group">
                             <label>Enter your name</label>
                             <input type=text class="form-control" id="name" name="name" placeholder="John">
@@ -45,10 +45,10 @@ var (
 
         <!-- You may want to store this in a separate file -->
         <script type="text/javascript">
-            $(".example").submit(function(e) {
+            $(".{{.Alias}}").submit(function(e) {
                 e.preventDefault();
 
-		var url = window.location.href.replace(/\/$/, "") + "/example/call";
+		var url = window.location.href.replace(/\/$/, "") + "/{{.Alias}}/call";
                 var data = $(this).serializeArray()[0];
                 var name = data.value;
                 if (name.length == 0) {

--- a/internal/template/main.go
+++ b/internal/template/main.go
@@ -21,10 +21,10 @@ func main() {
 	function.Init()
 
 	// Register Handler
-	function.Handle(new(handler.Example))
+	function.Handle(new(handler.{{title .Alias}}))
 
 	// Register Struct as Subscriber
-	function.Subscribe("{{.FQDN}}", new(subscriber.Example))
+	function.Subscribe("{{.FQDN}}", new(subscriber.{{title .Alias}}))
 
 	// Run service
 	if err := function.Run(); err != nil {
@@ -41,7 +41,7 @@ import (
 	"{{.Dir}}/handler"
 	"{{.Dir}}/subscriber"
 
-	example "{{.Dir}}/proto/example"
+	{{.Alias}} "{{.Dir}}/proto/{{.Alias}}"
 )
 
 func main() {
@@ -55,10 +55,10 @@ func main() {
 	service.Init()
 
 	// Register Handler
-	example.RegisterExampleHandler(service.Server(), new(handler.Example))
+	{{.Alias}}.Register{{title .Alias}}Handler(service.Server(), new(handler.{{title .Alias}}))
 
 	// Register Struct as Subscriber
-	micro.RegisterSubscriber("{{.FQDN}}", service.Server(), new(subscriber.Example))
+	micro.RegisterSubscriber("{{.FQDN}}", service.Server(), new(subscriber.{{title .Alias}}))
 
 	// Register Function as Subscriber
 	micro.RegisterSubscriber("{{.FQDN}}", service.Server(), subscriber.Handler)
@@ -78,7 +78,7 @@ import (
 	"{{.Dir}}/handler"
 	"{{.Dir}}/client"
 
-	example "{{.Dir}}/proto/example"
+	{{.Alias}} "{{.Dir}}/proto/{{.Alias}}"
 )
 
 func main() {
@@ -90,12 +90,12 @@ func main() {
 
 	// Initialise service
 	service.Init(
-		// create wrap for the Example srv client
-		micro.WrapHandler(client.ExampleWrapper(service)),
+		// create wrap for the {{title .Alias}} srv client
+		micro.WrapHandler(client.{{title .Alias}}Wrapper(service)),
 	)
 
 	// Register Handler
-	example.RegisterExampleHandler(service.Server(), new(handler.Example))
+	{{.Alias}}.Register{{title .Alias}}Handler(service.Server(), new(handler.{{title .Alias}}))
 
 	// Run service
 	if err := service.Run(); err != nil {
@@ -129,7 +129,7 @@ func main() {
 	service.Handle("/", http.FileServer(http.Dir("html")))
 
 	// register call handler
-	service.HandleFunc("/example/call", handler.ExampleCall)
+	service.HandleFunc("/{{.Alias}}/call", handler.{{title .Alias}}Call)
 
 	// run service
         if err := service.Run(); err != nil {

--- a/internal/template/makefile.go
+++ b/internal/template/makefile.go
@@ -7,7 +7,7 @@ GOPATH:=$(shell go env GOPATH)
 {{if ne .Type "web"}}
 .PHONY: proto
 proto:
-	protoc --proto_path=${GOPATH}/src:. --micro_out=. --go_out=. proto/example/example.proto
+	protoc --proto_path=${GOPATH}/src:. --micro_out=. --go_out=. proto/{{.Alias}}/{{.Alias}}.proto
 
 .PHONY: build
 build: proto

--- a/internal/template/proto.go
+++ b/internal/template/proto.go
@@ -5,7 +5,7 @@ var (
 
 package {{.FQDN}};
 
-service Example {
+service {{title .Alias}} {
 	rpc Call(Request) returns (Response) {}
 }
 
@@ -26,7 +26,7 @@ message Response {
 
 package {{.FQDN}};
 
-service Example {
+service {{title .Alias}} {
 	rpc Call(Request) returns (Response) {}
 	rpc Stream(StreamingRequest) returns (stream StreamingResponse) {}
 	rpc PingPong(stream Ping) returns (stream Pong) {}
@@ -67,7 +67,7 @@ package {{.FQDN}};
 
 import "github.com/micro/go-api/proto/api.proto";
 
-service Example {
+service {{title .Alias}} {
 	rpc Call(go.api.Request) returns (go.api.Response) {}
 }
 `

--- a/internal/template/wrapper.go
+++ b/internal/template/wrapper.go
@@ -8,24 +8,24 @@ import (
 
 	"github.com/micro/go-micro"
 	"github.com/micro/go-micro/server"
-	example "github.com/micro/examples/template/srv/proto/example"
+	{{.Alias}} "path/to/service/proto/{{.Alias}}"
 )
 
-type exampleKey struct {}
+type {{.Alias}}Key struct {}
 
 // FromContext retrieves the client from the Context
-func ExampleFromContext(ctx context.Context) (example.ExampleService, bool) {
-	c, ok := ctx.Value(exampleKey{}).(example.ExampleService)
+func {{title .Alias}}FromContext(ctx context.Context) ({{.Alias}}.{{title .Alias}}Service, bool) {
+	c, ok := ctx.Value({{.Alias}}Key{}).({{.Alias}}.{{title .Alias}}Service)
 	return c, ok
 }
 
-// Client returns a wrapper for the ExampleClient
-func ExampleWrapper(service micro.Service) server.HandlerWrapper {
-	client := example.NewExampleService("go.micro.srv.template", service.Client())
+// Client returns a wrapper for the {{title .Alias}}Client
+func {{title .Alias}}Wrapper(service micro.Service) server.HandlerWrapper {
+	client := {{.Alias}}.New{{title .Alias}}Service("go.micro.srv.template", service.Client())
 
 	return func(fn server.HandlerFunc) server.HandlerFunc {
 		return func(ctx context.Context, req server.Request, rsp interface{}) error {
-			ctx = context.WithValue(ctx, exampleKey{}, client)
+			ctx = context.WithValue(ctx, {{.Alias}}Key{}, client)
 			return fn(ctx, req, rsp)
 		}
 	}

--- a/new/new.go
+++ b/new/new.go
@@ -206,6 +206,9 @@ func run(ctx *cli.Context) {
 	if len(alias) == 0 {
 		// set as last part
 		alias = filepath.Base(dir)
+		// strip hyphens
+		parts := strings.Split(alias, "-")
+		alias = parts[0]
 	}
 
 	if len(fqdn) == 0 {
@@ -242,9 +245,9 @@ func run(ctx *cli.Context) {
 			Files: []file{
 				{"main.go", tmpl.MainFNC},
 				{"plugin.go", tmpl.Plugin},
-				{"handler/example.go", tmpl.HandlerFNC},
-				{"subscriber/example.go", tmpl.SubscriberFNC},
-				{"proto/example/example.proto", tmpl.ProtoFNC},
+				{"handler/" + alias + ".go", tmpl.HandlerFNC},
+				{"subscriber/" + alias + ".go", tmpl.SubscriberFNC},
+				{"proto/" + alias + "/" + alias + ".proto", tmpl.ProtoFNC},
 				{"Dockerfile", tmpl.DockerFNC},
 				{"Makefile", tmpl.Makefile},
 				{"README.md", tmpl.ReadmeFNC},
@@ -254,9 +257,9 @@ func run(ctx *cli.Context) {
 				"brew install protobuf",
 				"go get -u github.com/golang/protobuf/{proto,protoc-gen-go}",
 				"go get -u github.com/micro/protoc-gen-micro",
-				"\ncompile the proto file example.proto:\n",
+				"\ncompile the proto file " + alias + ".proto:\n",
 				"cd " + goDir,
-				"protoc --proto_path=.:$GOPATH/src --go_out=. --micro_out=. proto/example/example.proto\n",
+				"protoc --proto_path=.:$GOPATH/src --go_out=. --micro_out=. proto/" + alias + "/" + alias + ".proto\n",
 			},
 		}
 	case "srv":
@@ -274,9 +277,9 @@ func run(ctx *cli.Context) {
 			Files: []file{
 				{"main.go", tmpl.MainSRV},
 				{"plugin.go", tmpl.Plugin},
-				{"handler/example.go", tmpl.HandlerSRV},
-				{"subscriber/example.go", tmpl.SubscriberSRV},
-				{"proto/example/example.proto", tmpl.ProtoSRV},
+				{"handler/" + alias + ".go", tmpl.HandlerSRV},
+				{"subscriber/" + alias + ".go", tmpl.SubscriberSRV},
+				{"proto/" + alias + "/" + alias + ".proto", tmpl.ProtoSRV},
 				{"Dockerfile", tmpl.DockerSRV},
 				{"Makefile", tmpl.Makefile},
 				{"README.md", tmpl.Readme},
@@ -286,9 +289,9 @@ func run(ctx *cli.Context) {
 				"brew install protobuf",
 				"go get -u github.com/golang/protobuf/{proto,protoc-gen-go}",
 				"go get -u github.com/micro/protoc-gen-micro",
-				"\ncompile the proto file example.proto:\n",
+				"\ncompile the proto file " + alias + ".proto:\n",
 				"cd " + goDir,
-				"protoc --proto_path=.:$GOPATH/src --go_out=. --micro_out=. proto/example/example.proto\n",
+				"protoc --proto_path=.:$GOPATH/src --go_out=. --micro_out=. proto/" + alias + "/" + alias + ".proto\n",
 			},
 		}
 	case "api":
@@ -306,9 +309,9 @@ func run(ctx *cli.Context) {
 			Files: []file{
 				{"main.go", tmpl.MainAPI},
 				{"plugin.go", tmpl.Plugin},
-				{"client/example.go", tmpl.WrapperAPI},
-				{"handler/example.go", tmpl.HandlerAPI},
-				{"proto/example/example.proto", tmpl.ProtoAPI},
+				{"client/" + alias + ".go", tmpl.WrapperAPI},
+				{"handler/" + alias + ".go", tmpl.HandlerAPI},
+				{"proto/" + alias + "/" + alias + ".proto", tmpl.ProtoAPI},
 				{"Makefile", tmpl.Makefile},
 				{"Dockerfile", tmpl.DockerSRV},
 				{"README.md", tmpl.Readme},
@@ -318,9 +321,9 @@ func run(ctx *cli.Context) {
 				"brew install protobuf",
 				"go get -u github.com/golang/protobuf/{proto,protoc-gen-go}",
 				"go get -u github.com/micro/protoc-gen-micro",
-				"\ncompile the proto file example.proto:\n",
+				"\ncompile the proto file " + alias + ".proto:\n",
 				"cd " + goDir,
-				"protoc --proto_path=.:$GOPATH/src --go_out=. --micro_out=. proto/example/example.proto\n",
+				"protoc --proto_path=.:$GOPATH/src --go_out=. --micro_out=. proto/" + alias + "/" + alias + ".proto\n",
 			},
 		}
 	case "web":


### PR DESCRIPTION
This PR customises template generation so that we don't just generate "example" everywhere but actually use the name provided. In the case the alias is not provided and the directory name is hyphenated we only use the first part of the name for the alias.