### PR TITLE
Table has moved to dedicated package

### DIFF
--- a/router/handler/handler.go
+++ b/router/handler/handler.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/micro/go-micro/network/router"
 	pb "github.com/micro/go-micro/network/router/proto"
+	"github.com/micro/go-micro/network/router/table"
 )
 
 type Router struct {
@@ -13,8 +14,8 @@ type Router struct {
 }
 
 func (r *Router) Lookup(ctx context.Context, req *pb.LookupRequest, resp *pb.LookupResponse) error {
-	query := router.NewQuery(
-		router.QueryDestination(req.Query.Destination),
+	query := table.NewQuery(
+		table.QueryDestination(req.Query.Destination),
 	)
 
 	routes, err := r.Router.Table().Lookup(query)

--- a/router/handler/handler.go
+++ b/router/handler/handler.go
@@ -15,7 +15,7 @@ type Router struct {
 
 func (r *Router) Lookup(ctx context.Context, req *pb.LookupRequest, resp *pb.LookupResponse) error {
 	query := table.NewQuery(
-		table.QueryDestination(req.Query.Destination),
+		table.QueryService(req.Query.Service),
 	)
 
 	routes, err := r.Router.Table().Lookup(query)
@@ -26,11 +26,12 @@ func (r *Router) Lookup(ctx context.Context, req *pb.LookupRequest, resp *pb.Loo
 	var respRoutes []*pb.Route
 	for _, route := range routes {
 		respRoute := &pb.Route{
-			Destination: route.Destination,
-			Gateway:     route.Gateway,
-			Router:      route.Router,
-			Network:     route.Network,
-			Metric:      int64(route.Metric),
+			Service: route.Service,
+			Address: route.Address,
+			Gateway: route.Gateway,
+			Network: route.Network,
+			Link:    route.Link,
+			Metric:  int64(route.Metric),
 		}
 		respRoutes = append(respRoutes, respRoute)
 	}


### PR DESCRIPTION
This PR adds changes required due to https://github.com/micro/go-micro/pull/573

The only required change here was due to routing table code in `go-micro` being moved to dedicated `table` package.

*DO NOT MERGE BEFORE go-micro PR IS MERGED*