### PR TITLE
Fix tunnel

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -18,7 +18,7 @@ var (
 	// Name of the server microservice
 	Name = "go.micro.server"
 	// Address is the router microservice bind address
-	Address = ":8083"
+	Address = ":8087"
 	// Router is the router address a.k.a. gossip address
 	Router = ":9093"
 	// Network is the router network id

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -118,6 +118,7 @@ func run(ctx *cli.Context, srvOpts ...micro.Option) {
 
 	// local proxy
 	tunProxy := mucp.NewProxy(
+		proxy.WithRouter(r),
 		proxy.WithClient(tunSrvClient),
 	)
 

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -98,7 +98,6 @@ func run(ctx *cli.Context, srvOpts ...micro.Option) {
 
 	// local proxy
 	localProxy := mucp.NewProxy(
-		proxy.WithRouter(r),
 		proxy.WithClient(localSrvClient),
 		proxy.WithEndpoint(Tunnel),
 	)


### PR DESCRIPTION
We were previously using the default router which used to pull routes from registry when created. We're now using the this locally initialised router thats started.