### PR TITLE
Add health check command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -87,6 +87,16 @@ func runc(c *cli.Context) {
 	}
 }
 
+func HealthCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:   "check",
+			Usage:  "Query the health of a service",
+			Action: printer(queryHealth),
+		},
+	}
+}
+
 func NetworkCommands() []cli.Command {
 	return []cli.Command{
 		{
@@ -188,11 +198,6 @@ func Commands() []cli.Command {
 			Name:   "publish",
 			Usage:  "Publish a message to a topic",
 			Action: printer(publish),
-		},
-		{
-			Name:   "health",
-			Usage:  "Query the health of a service",
-			Action: printer(queryHealth),
 		},
 		{
 			Name:   "stats",

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/micro/micro/api"
 	"github.com/micro/micro/bot"
 	"github.com/micro/micro/cli"
+	"github.com/micro/micro/health"
 	"github.com/micro/micro/monitor"
 	"github.com/micro/micro/network"
 	"github.com/micro/micro/new"
@@ -199,6 +200,7 @@ func Setup(app *ccli.App, options ...micro.Option) {
 	app.Commands = append(app.Commands, api.Commands(options...)...)
 	app.Commands = append(app.Commands, bot.Commands()...)
 	app.Commands = append(app.Commands, cli.Commands()...)
+	app.Commands = append(app.Commands, health.Commands(options...)...)
 	app.Commands = append(app.Commands, proxy.Commands(options...)...)
 	app.Commands = append(app.Commands, monitor.Commands(options...)...)
 	app.Commands = append(app.Commands, router.Commands(options...)...)

--- a/health/health.go
+++ b/health/health.go
@@ -1,0 +1,101 @@
+// Package health is a healthchecking sidecar
+package health
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/micro/cli"
+	"github.com/micro/go-micro"
+	"github.com/micro/go-micro/client"
+	proto "github.com/micro/go-micro/debug/proto"
+	"github.com/micro/go-micro/util/log"
+	mcli "github.com/micro/micro/cli"
+	"golang.org/x/net/context"
+)
+
+var (
+	healthAddress = "127.0.0.1:8088"
+	serverAddress string
+	serverName    string
+)
+
+func run(ctx *cli.Context) {
+	serverName = ctx.String("check_service")
+	serverAddress = ctx.String("check_address")
+
+	if addr := ctx.String("health_address"); len(addr) > 0 {
+		healthAddress = addr
+	}
+
+	if len(healthAddress) == 0 {
+		log.Fatal("health address not set")
+	}
+	if len(serverName) == 0 {
+		log.Fatal("service name not set")
+	}
+	if len(serverAddress) == 0 {
+		log.Fatal("service address not set")
+	}
+
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		req := client.NewRequest(serverName, "Debug.Health", &proto.HealthRequest{})
+		rsp := &proto.HealthResponse{}
+
+		err := client.Call(context.TODO(), req, rsp, client.WithAddress(serverAddress))
+		if err != nil || rsp.Status != "ok" {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, "NOT_HEALTHY")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "OK")
+	})
+
+	log.Infof("Health check running at %s/health", healthAddress)
+	log.Infof("Health check defined for %s at %s", serverName, serverAddress)
+
+	if err := http.ListenAndServe(healthAddress, nil); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func Commands(options ...micro.Option) []cli.Command {
+	command := cli.Command{
+		Name:  "health",
+		Usage: "Run the http healthchecking sidecar at /health",
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:   "address",
+				Usage:  "Set the address exposed for the http server e.g :8088",
+				EnvVar: "MICRO_HEALTH_ADDRESS",
+			},
+			cli.StringFlag{
+				Name:   "check_service",
+				Usage:  "Name of the service to query",
+				EnvVar: "MICRO_HEALTH_CHECK_SERVICE",
+			},
+			cli.StringFlag{
+				Name:   "check_address",
+				Usage:  "Set the service address to query",
+				EnvVar: "MICRO_HEALTH_CHECK_ADDRESS",
+			},
+		},
+		Subcommands: mcli.HealthCommands(),
+		Action: func(ctx *cli.Context) {
+			run(ctx)
+		},
+	}
+
+	for _, p := range Plugins() {
+		if cmds := p.Commands(); len(cmds) > 0 {
+			command.Subcommands = append(command.Subcommands, cmds...)
+		}
+
+		if flags := p.Flags(); len(flags) > 0 {
+			command.Flags = append(command.Flags, flags...)
+		}
+	}
+
+	return []cli.Command{command}
+}

--- a/health/plugin.go
+++ b/health/plugin.go
@@ -1,0 +1,26 @@
+package health
+
+import (
+	"fmt"
+
+	"github.com/micro/micro/plugin"
+)
+
+var (
+	defaultManager = plugin.NewManager()
+)
+
+// Plugins lists the api plugins
+func Plugins() []plugin.Plugin {
+	return defaultManager.Plugins()
+}
+
+// Register registers an api plugin
+func Register(pl plugin.Plugin) error {
+	for _, p := range plugin.Plugins() {
+		if p.String() == pl.String() {
+			return fmt.Errorf("%s registered globally", pl.String())
+		}
+	}
+	return defaultManager.Register(pl)
+}


### PR DESCRIPTION
The healthchecking sidecar is moving to the command `micro health`. This can be used as follows.

```
micro health --check_service=go.micro.srv.greeter --check_address=localhost:9090
```

It runs at the default address localhost:8088/health

Healthchecks can be run on the command line as

```
micro health check go.micro.srv.greeter
```