### PR TITLE
Update health.go

### DIFF
--- a/health/health.go
+++ b/health/health.go
@@ -66,7 +66,7 @@ func Commands(options ...micro.Option) []cli.Command {
 		Usage: "Run the http healthchecking sidecar at /health",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:   "address",
+				Name:   "health_address",
 				Usage:  "Set the address exposed for the http server e.g :8088",
 				EnvVar: "MICRO_HEALTH_ADDRESS",
 			},


### PR DESCRIPTION
found this bug, as I could not overwrite `healthAddress` with  `--address=0.0.0.0:8080`  flag.   
on the side note, I would prefer using `0.0.0.0` as default address. i.g.,  healthAddress = "0.0.0.0:8088"