### PR TITLE
Enhancing micro version information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+_build
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# ignore go build and test outputs
+coverage.txt
+coverage.out
+
+# ignore locally built binaries
+micro

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ build:
 docker:
 	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) .
 	docker tag $(IMAGE_NAME):$(IMAGE_TAG) $(IMAGE_NAME):latest
-	#docker push $(IMAGE_NAME):$(IMAGE_TAG)
-	#docker push $(IMAGE_NAME):latest
+	docker push $(IMAGE_NAME):$(IMAGE_TAG)
+	docker push $(IMAGE_NAME):latest
 
 vet:
 	go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 NAME=micro
 IMAGE_NAME=micro/$(NAME)
-TAG=$(shell git describe --abbrev=0 --tags)
+GIT_COMMIT=$(shell git rev-parse --short HEAD)
+GIT_TAG=$(shell git describe --abbrev=0 --tags --always --match "v*")
+GIT_IMPORT=github.com/micro/micro/cmd
 CGO_ENABLED=0
+BUILD_DATE=$(shell date +%FT%T%z)
+LDFLAGS=-X $(GIT_IMPORT).GitCommit=$(GIT_COMMIT) -X $(GIT_IMPORT).GitTag=$(GIT_TAG) -X $(GIT_IMPORT).BuildDate=$(BUILD_DATE)
+IMAGE_TAG=$(GIT_TAG)-$(GIT_COMMIT)
 
 all: build
 
@@ -10,13 +15,13 @@ vendor:
 
 build:
 	go get
-	go build -a -installsuffix cgo -ldflags '-w' -o $(NAME) ./*.go
+	go build -a -installsuffix cgo -ldflags "-w ${LDFLAGS}" -o $(NAME) ./*.go
 
 docker:
-	docker build -t $(IMAGE_NAME):$(TAG) .
-	docker tag $(IMAGE_NAME):$(TAG) $(IMAGE_NAME):latest
-	docker push $(IMAGE_NAME):$(TAG)
-	docker push $(IMAGE_NAME):latest
+	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) .
+	docker tag $(IMAGE_NAME):$(IMAGE_TAG) $(IMAGE_NAME):latest
+	#docker push $(IMAGE_NAME):$(IMAGE_TAG)
+	#docker push $(IMAGE_NAME):latest
 
 vet:
 	go vet ./...

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -209,8 +209,6 @@ func setup(app *ccli.App) {
 func buildVersion() string {
 	microVersion := version
 
-	fmt.Printf("GitTag: %s\n", GitTag)
-
 	if GitTag != "" {
 		microVersion = GitTag
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -35,6 +35,10 @@ import (
 )
 
 var (
+	GitCommit string
+	GitTag    string
+	BuildDate string
+
 	name        = "micro"
 	description = "A microservice runtime"
 	version     = "1.11.0"
@@ -202,6 +206,26 @@ func setup(app *ccli.App) {
 	}
 }
 
+func buildVersion() string {
+	microVersion := version
+
+	fmt.Printf("GitTag: %s\n", GitTag)
+
+	if GitTag != "" {
+		microVersion = GitTag
+	}
+
+	if GitCommit != "" {
+		microVersion += fmt.Sprintf(" (%s)", GitCommit)
+	}
+
+	if BuildDate != "" {
+		microVersion += fmt.Sprintf(" (%s)", BuildDate)
+	}
+
+	return microVersion
+}
+
 // Init initialised the command line
 func Init(options ...micro.Option) {
 	Setup(cmd.App(), options...)
@@ -209,7 +233,7 @@ func Init(options ...micro.Option) {
 	cmd.Init(
 		cmd.Name(name),
 		cmd.Description(description),
-		cmd.Version(version),
+		cmd.Version(buildVersion()),
 	)
 }
 


### PR DESCRIPTION
At the moment we are hardcoding the version of micro into the source code. This is usually ok, but we can do better.

By updating `make build` task this commit allows (but does not enforce!) the following:
* adding `git tag`, `git commit` and build date into `micro` version output
* tags docker image with both the tag and the commit
* adds a `.gitignore` file that prevents committing binaries or other unnecessary files (this is almost exact copy of the .gitignore file provided by default by GitHub when creating a new `Go` project)

What do the results look like when `make build` is invoked:
```shell
$ ./micro --version
micro version v1.11.0 (2802bc4) (2019-10-15T23:50:36+0100)
```
`make  docker` tags the `micro` image with the following tags which give a glimpse of the most recent `git` tag and `git` commit sha:
```shell
micro/micro         latest              1004ee70ea61        9 seconds ago       43.1MB
micro/micro         v1.11.0-2802bc4     1004ee70ea61        9 seconds ago       43.1MB
```

If `micro` is built without invoking `make build` the extra information is not added to the version output.