### PR TITLE
Added goreleaser and tighub action for auto-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: release
+
+on:
+  push:
+    branches-ignore:
+      - '**'
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@master
+      -
+        name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: '1.13'
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ coverage.out
 
 # ignore locally built binaries
 micro
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,46 @@
+project_name: micro
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go mod download
+builds:
+- binary: micro
+  env:
+    - CGO_ENABLED=0
+  ldflags: -w -X github.com/micro/micro/cmd.GitCommit={{ .ShortCommit }} -X github.com/micro/micro/cmd.GitTag={{ .Tag }} -X github.com/micro/micro/cmd.BuildDate={{ .Timestamp }}
+  goos:
+    - linux
+    - darwin
+    - windows
+  goarch:
+    - amd64
+    - arm
+    - arm64
+  goarm:
+    - 7
+archives:
+- replacements:
+    darwin: darwin
+    linux: linux
+    windows: windows
+    amd64: x86_64
+    arm: arm
+    arm64: arm64
+  format: tar.gz
+  format_overrides:
+  - goos: windows
+    format: zip
+  files:
+    - LICENSE
+    - README.md
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'


### PR DESCRIPTION
This PR adds the following:
* `.goreleaser` config to automatically build `micro` releases using [goreleaser](https://github.com/goreleaser/goreleaser)
* [github-action](https://github.com/features/actions) for releasing `micro`: this will automatically trigger `goreleaser` action by simply pushing a tag \o/

**NOTE: ** you can test `goreleaser` locally without publishing anything to github by running the following:
```
goreleaser --skip-validate --skip-publish --rm-dist
```

Equally, if you want to do a manual release from your local machine you can simply run:
```
goreleaser
```

**NOTE:** Manual release will only work if you export `GITHUB_TOKEN`l; GitHub actions generate token for every action automatically \o/