### PR TITLE
add micro network connections cli command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -101,8 +101,13 @@ func NetworkCommands() []cli.Command {
 	return []cli.Command{
 		{
 			Name:   "connect",
-			Usage:  "Connect to the network. Specify nodes e.g connect ip:port",
+			Usage:  "connect to the network. specify nodes e.g connect ip:port",
 			Action: printer(networkConnect),
+		},
+		{
+			Name:   "connections",
+			Usage:  "List the immediate connections to the network",
+			Action: printer(networkConnections),
 		},
 		{
 			Name:   "graph",

--- a/cli/helpers.go
+++ b/cli/helpers.go
@@ -51,6 +51,10 @@ func networkConnect(c *cli.Context, args []string) ([]byte, error) {
 	return clic.NetworkConnect(c, args)
 }
 
+func networkConnections(c *cli.Context, args []string) ([]byte, error) {
+	return clic.NetworkConnections(c)
+}
+
 func networkGraph(c *cli.Context, args []string) ([]byte, error) {
 	return clic.NetworkGraph(c)
 }


### PR DESCRIPTION
Displays immediate connections via `micro network connections`.

This differs from `micro network nodes` in that network nodes tells you whats on the network but not exactly you're connected to.

```$ micro network connections
+--------------------------------------+---------------------+
|                 NODE                 |       ADDRESS       |
+--------------------------------------+---------------------+
| b0b734a5-08d5-415f-8cc7-a175c6945e1c | 178.62.1.39:30038   |
| 287d8c80-c47f-47f3-b468-4a2b3ab4cc97 | 34.94.97.76:30038   |
| 0aa7656a-2c5e-4df0-b84f-bb5a0ebbc30c | 35.236.22.94:30038  |
| 99eaea5d-c5dc-44ee-9352-1b837acbc0b6 | 178.62.14.60:30038  |
| eaf7a6bd-75da-406f-9512-4cef5e7ede9c | 18.162.148.89:30038 |
+--------------------------------------+---------------------+```