### PR TITLE
Alight table columns to the right

### DIFF
--- a/internal/command/cli/command.go
+++ b/internal/command/cli/command.go
@@ -327,6 +327,7 @@ func NetworkConnections(c *cli.Context) ([]byte, error) {
 	}
 
 	// render table into b
+	table.SetAlignment(tablewriter.ALIGN_RIGHT)
 	table.Render()
 
 	return b.Bytes(), nil
@@ -383,6 +384,7 @@ func NetworkNodes(c *cli.Context) ([]byte, error) {
 	}
 
 	// render table into b
+	table.SetAlignment(tablewriter.ALIGN_RIGHT)
 	table.Render()
 
 	return b.Bytes(), nil
@@ -458,6 +460,7 @@ func NetworkRoutes(c *cli.Context) ([]byte, error) {
 	}
 
 	// render table into b
+	table.SetAlignment(tablewriter.ALIGN_RIGHT)
 	table.Render()
 
 	return b.Bytes(), nil


### PR DESCRIPTION
This PR will allign *ALL* entries in each column to the right side. Previously, the numberic and IP entries would render inconsistently, now we get this:

```
+--------------------------------------+----------------------+
|                  ID                  |       ADDRESS        |
+--------------------------------------+----------------------+
| fe742116-80b3-42aa-8a14-da43b8e0d83c |  4329099016106923836 |
| f1d7bf19-0390-40d5-87b1-13639d067beb |   178.62.14.60:30038 |
| 8e8755c5-a3ed-43f5-9e6f-0363cac916be |  8455722850307352675 |
+--------------------------------------+----------------------+
```