### PR TITLE
Implement network dns advertise, call, resolve

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -214,7 +214,7 @@ func NetworkDNSCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:   "type",
-					Usage:  "Domain name to remove",
+					Usage:  "Domain name type to resolve",
 					EnvVar: "MICRO_NETWORK_DNS_RESOLVE_TYPE",
 					Value:  "A",
 				},

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -154,6 +154,81 @@ func NetworkCommands() []cli.Command {
 	}
 }
 
+func NetworkDNSCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:  "advertise",
+			Usage: "Advertise a new node to the network",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:   "address",
+					Usage:  "Address to register for the specified domain",
+					EnvVar: "MICRO_NETWORK_DNS_ADVERTISE_ADDRESS",
+				},
+				cli.StringFlag{
+					Name:   "domain",
+					Usage:  "Domain name to register",
+					EnvVar: "MICRO_NETWORK_DNS_ADVERTISE_DOMAIN",
+					Value:  "network.micro.mu",
+				},
+				cli.StringFlag{
+					Name:   "token",
+					Usage:  "Bearer token for the go.micro.network.dns service",
+					EnvVar: "MICRO_NETWORK_DNS_ADVERTISE_TOKEN",
+				},
+			},
+			Action: printer(netDNSAdvertise),
+		},
+		{
+			Name:  "remove",
+			Usage: "Remove a node's record'",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:   "address",
+					Usage:  "Address to register for the specified domain",
+					EnvVar: "MICRO_NETWORK_DNS_REMOVE_ADDRESS",
+				},
+				cli.StringFlag{
+					Name:   "domain",
+					Usage:  "Domain name to remove",
+					EnvVar: "MICRO_NETWORK_DNS_REMOVE_DOMAIN",
+					Value:  "network.micro.mu",
+				},
+				cli.StringFlag{
+					Name:   "token",
+					Usage:  "Bearer token for the go.micro.network.dns service",
+					EnvVar: "MICRO_NETWORK_DNS_REMOVE_TOKEN",
+				},
+			},
+			Action: printer(netDNSRemove),
+		},
+		{
+			Name:  "resolve",
+			Usage: "Remove a record'",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:   "domain",
+					Usage:  "Domain name to resolve",
+					EnvVar: "MICRO_NETWORK_DNS_RESOLVE_DOMAIN",
+					Value:  "network.micro.mu",
+				},
+				cli.StringFlag{
+					Name:   "type",
+					Usage:  "Domain name to remove",
+					EnvVar: "MICRO_NETWORK_DNS_RESOLVE_TYPE",
+					Value:  "A",
+				},
+				cli.StringFlag{
+					Name:   "token",
+					Usage:  "Bearer token for the go.micro.network.dns service",
+					EnvVar: "MICRO_NETWORK_DNS_RESOLVE_TOKEN",
+				},
+			},
+			Action: printer(netDNSResolve),
+		},
+	}
+}
+
 func RegistryCommands() []cli.Command {
 	return []cli.Command{
 		{

--- a/cli/helpers.go
+++ b/cli/helpers.go
@@ -71,6 +71,18 @@ func netServices(c *cli.Context, args []string) ([]byte, error) {
 	return clic.NetworkServices(c)
 }
 
+func netDNSAdvertise(c *cli.Context, args []string) ([]byte, error) {
+	return clic.NetworkDNSAdvertise(c)
+}
+
+func netDNSRemove(c *cli.Context, args []string) ([]byte, error) {
+	return clic.NetworkDNSRemove(c)
+}
+
+func netDNSResolve(c *cli.Context, args []string) ([]byte, error) {
+	return clic.NetworkDNSResolve(c)
+}
+
 func listServices(c *cli.Context, args []string) ([]byte, error) {
 	return clic.ListServices(c)
 }

--- a/network/network.go
+++ b/network/network.go
@@ -261,6 +261,7 @@ func Commands(options ...micro.Option) []cli.Command {
 				Action: func(ctx *cli.Context) {
 					netdns.Run(ctx)
 				},
+				Subcommands: mcli.NetworkDNSCommands(),
 			},
 		}, mcli.NetworkCommands()...),
 		Action: func(ctx *cli.Context) {


### PR DESCRIPTION
This means that you can register network node records from the command line, which will be useful for core nodes to register themselves for discovery.