### PR TITLE
Add retries to network dns calls

### DIFF
--- a/internal/command/cli/command.go
+++ b/internal/command/cli/command.go
@@ -546,6 +546,7 @@ func NetworkDNSResolve(c *cli.Context) ([]byte, error) {
 		}),
 		req,
 		&rsp,
+		client.WithRetries(3),
 	)
 	if err != nil {
 		return []byte(``), err
@@ -597,6 +598,7 @@ func networkDNSHelper(action, address, domain, token string) error {
 		}),
 		req,
 		&rsp,
+		client.WithRetries(3),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
In case there's any transient failure in resolving go.micro.network.dns (as we saw over the weekend)