### PR TITLE
 If no GOPATH is set, use default path.

### DIFF
--- a/new/new.go
+++ b/new/new.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"go/build"
 
 	"github.com/micro/cli"
 	tmpl "github.com/micro/micro/internal/template"
@@ -184,7 +185,7 @@ func run(ctx *cli.Context) {
 
 	// only set gopath if told to use it
 	if useGoPath {
-		goPath = os.Getenv("GOPATH")
+		goPath = build.Default.GOPATH
 
 		// don't know GOPATH, runaway....
 		if len(goPath) == 0 {


### PR DESCRIPTION
If no GOPATH is set, it is assumed to be $HOME/go on Unix systems and %USERPROFILE%\go on Windows. 
href: https://github.com/golang/go/wiki/SettingGOPATH

`build.Default.GOPATH` will get from the environment or default value.
href: https://golang.org/pkg/go/build/