### PR TITLE
return a specific type of "runtime" service

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -63,7 +63,13 @@ func initCommand(context *cli.Context) {
 		os.Exit(1)
 	}
 
+	// services to manage
 	services := []string{
+		// network services
+		"network.api",
+		"network.dns",
+		"network.web",
+		// runtime services
 		"network",  // :8085
 		"runtime",  // :8088
 		"registry", // :8000
@@ -96,9 +102,11 @@ func initCommand(context *cli.Context) {
 	// individual events for each service
 	options := []gorun.Option{
 		gorun.WithNotifier(wrapped),
+		gorun.WithType("runtime"),
 	}
 	(*muRuntime).Init(options...)
 
+	// used to signal when to shutdown
 	shutdown := make(chan os.Signal, 1)
 	signal.Notify(shutdown, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/hako/branca v0.0.0-20180808000428-10b799466ada
 	github.com/micro/cli v0.2.0
-	github.com/micro/go-micro v1.17.1
+	github.com/micro/go-micro v1.17.2-0.20191129115525-76b4e78a6ac2
 	github.com/miekg/dns v1.1.22
 	github.com/olekukonko/tablewriter v0.0.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -306,6 +306,10 @@ github.com/micro/go-micro v1.17.0 h1:2g4oL/KdLl/effh3TENqKhaDZP9WnZnJciGTgOtDtXk
 github.com/micro/go-micro v1.17.0/go.mod h1:klwUJL1gkdY1MHFyz+fFJXn52dKcty4hoe95Mp571AA=
 github.com/micro/go-micro v1.17.1 h1:BhwC4Lnwr3hdci9T8kN5MEabKS+CT0QT0YH4hinTdNs=
 github.com/micro/go-micro v1.17.1/go.mod h1:klwUJL1gkdY1MHFyz+fFJXn52dKcty4hoe95Mp571AA=
+github.com/micro/go-micro v1.17.2-0.20191129114621-8b6475b8d401 h1:z+hUQayh0eMIQjMriM0akqhOMCHpAr2lEj94XMZjEJc=
+github.com/micro/go-micro v1.17.2-0.20191129114621-8b6475b8d401/go.mod h1:klwUJL1gkdY1MHFyz+fFJXn52dKcty4hoe95Mp571AA=
+github.com/micro/go-micro v1.17.2-0.20191129115525-76b4e78a6ac2 h1:fu8zMjnSs0sfkYDpxeoOahWn41OBAPx8mC+XLZKi+sk=
+github.com/micro/go-micro v1.17.2-0.20191129115525-76b4e78a6ac2/go.mod h1:klwUJL1gkdY1MHFyz+fFJXn52dKcty4hoe95Mp571AA=
 github.com/micro/mdns v0.3.0 h1:bYycYe+98AXR3s8Nq5qvt6C573uFTDPIYzJemWON0QE=
 github.com/micro/mdns v0.3.0/go.mod h1:KJ0dW7KmicXU2BV++qkLlmHYcVv7/hHnbtguSWt9Aoc=
 github.com/micro/protoc-gen-micro v1.0.0/go.mod h1:C8ij4DJhapBmypcT00AXdb0cZ675/3PqUO02buWWqbE=

--- a/network/config/kubernetes/services/micro/api-svc.yaml
+++ b/network/config/kubernetes/services/micro/api-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     name: micro-api
-    micro: service
+    micro: runtime
 spec:
   ports:
   - name: https
@@ -13,5 +13,5 @@ spec:
     targetPort: 443
   selector:
     name: micro-api
-    micro: service
+    micro: runtime
   type: LoadBalancer

--- a/network/config/kubernetes/services/micro/api.yaml
+++ b/network/config/kubernetes/services/micro/api.yaml
@@ -4,14 +4,14 @@ metadata:
   namespace: default
   name: micro-api
   labels:
-    micro: service
+    micro: runtime
     name: micro-api
 spec:
   replicas: 3
   selector:
     matchLabels:
       name: micro-api
-      micro: service
+      micro: runtime
   strategy:
     rollingUpdate:
       maxSurge: 0
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         name: micro-api
-        micro: service
+        micro: runtime
     spec:
       containers:
       - name: api

--- a/network/config/kubernetes/services/micro/bot.yaml
+++ b/network/config/kubernetes/services/micro/bot.yaml
@@ -4,19 +4,19 @@ metadata:
   namespace: default
   name: micro-bot
   labels:
-    micro: service
+    micro: runtime
     name: micro-bot
 spec:
   replicas: 1
   selector:
     matchLabels:
       name: micro-bot
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-bot
-        micro: service
+        micro: runtime
     spec:
       containers:
         - name: bot

--- a/network/config/kubernetes/services/micro/broker-svc.yaml
+++ b/network/config/kubernetes/services/micro/broker-svc.yaml
@@ -5,11 +5,11 @@ metadata:
   namespace: default
   labels:
     name: micro-broker
-    micro: service
+    micro: runtime
 spec:
   ports:
   - port: 8001
     protocol: TCP
   selector:
     name: micro-broker
-    micro: service
+    micro: runtime

--- a/network/config/kubernetes/services/micro/broker.yaml
+++ b/network/config/kubernetes/services/micro/broker.yaml
@@ -4,19 +4,19 @@ metadata:
   namespace: default
   name: micro-broker
   labels:
-    micro: service
+    micro: runtime
     name: micro-broker
 spec:
   replicas: 3
   selector:
     matchLabels:
       name: micro-broker
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-broker
-        micro: service
+        micro: runtime
     spec:
       containers:
       - name: broker

--- a/network/config/kubernetes/services/micro/init.yaml
+++ b/network/config/kubernetes/services/micro/init.yaml
@@ -49,19 +49,19 @@ metadata:
   namespace: default
   name: micro-init
   labels:
-    micro: service
+    micro: runtime
     name: micro-init
 spec:
   replicas: 1
   selector:
     matchLabels:
       name: micro-init
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-init
-        micro: service
+        micro: runtime
     spec:
       serviceAccountName: micro-init
       containers:

--- a/network/config/kubernetes/services/micro/monitor.yaml
+++ b/network/config/kubernetes/services/micro/monitor.yaml
@@ -4,19 +4,19 @@ metadata:
   namespace: default
   name: micro-monitor
   labels:
-    micro: service
+    micro: runtime
     name: micro-monitor
 spec:
   replicas: 1
   selector:
     matchLabels:
       name: micro-monitor
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-monitor
-        micro: service
+        micro: runtime
     spec:
       containers:
         - name: monitor

--- a/network/config/kubernetes/services/micro/network-api.yaml
+++ b/network/config/kubernetes/services/micro/network-api.yaml
@@ -4,18 +4,18 @@ metadata:
   namespace: default
   name: micro-network-api
   labels:
-    micro: service
+    micro: runtime
 spec:
   replicas: 1
   selector:
     matchLabels:
       name: micro-network-api
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-network-api
-        micro: service
+        micro: runtime
     spec:
       containers:
         - name: micro-network-api

--- a/network/config/kubernetes/services/micro/network-dns.yaml
+++ b/network/config/kubernetes/services/micro/network-dns.yaml
@@ -4,18 +4,18 @@ metadata:
   namespace: default
   name: micro-network-dns
   labels:
-    micro: service
+    micro: runtime
 spec:
   replicas: 2
   selector:
     matchLabels:
       name: micro-network-dns
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-network-dns
-        micro: service
+        micro: runtime
     spec:
       containers:
       - name: micro-network-dns

--- a/network/config/kubernetes/services/micro/network-svc.yaml
+++ b/network/config/kubernetes/services/micro/network-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     name: micro-network
-    micro: service
+    micro: runtime
 spec:
   type: NodePort
   ports:
@@ -15,7 +15,7 @@ spec:
     nodePort: 30038
   selector:
     name: micro-network
-    micro: service
+    micro: runtime
 ---
 apiVersion: v1
 kind: Service
@@ -24,7 +24,7 @@ metadata:
   namespace: default
   labels:
     name: micro-gateway
-    micro: service
+    micro: runtime
 spec:
   ports:
   - port: 8080
@@ -32,4 +32,4 @@ spec:
     name: service
   selector:
     name: micro-network
-    micro: service
+    micro: runtime

--- a/network/config/kubernetes/services/micro/network-web.yaml
+++ b/network/config/kubernetes/services/micro/network-web.yaml
@@ -4,18 +4,18 @@ metadata:
   namespace: default
   name: micro-network-web
   labels:
-    micro: service
+    micro: runtime
 spec:
   replicas: 1
   selector:
     matchLabels:
       name: micro-network-web
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-network-web
-        micro: service
+        micro: runtime
     spec:
       containers:
         - name: micro-network-web

--- a/network/config/kubernetes/services/micro/network.yaml
+++ b/network/config/kubernetes/services/micro/network.yaml
@@ -4,14 +4,14 @@ metadata:
   namespace: default
   name: micro-network
   labels:
-    micro: service
+    micro: runtime
     name: micro-network
 spec:
   replicas: 3
   selector:
     matchLabels:
       name: micro-network
-      micro: service
+      micro: runtime
   strategy:
     rollingUpdate:
       maxSurge: 0
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         name: micro-network
-        micro: service
+        micro: runtime
     spec:
       affinity:
         podAntiAffinity:

--- a/network/config/kubernetes/services/micro/proxy-svc.yaml
+++ b/network/config/kubernetes/services/micro/proxy-svc.yaml
@@ -5,11 +5,11 @@ metadata:
   namespace: default
   labels:
     name: micro-proxy
-    micro: service
+    micro: runtime
 spec:
   ports:
   - port: 8081
     protocol: TCP
   selector:
     name: micro-proxy
-    micro: service
+    micro: runtime

--- a/network/config/kubernetes/services/micro/proxy.yaml
+++ b/network/config/kubernetes/services/micro/proxy.yaml
@@ -4,19 +4,19 @@ metadata:
   namespace: default
   name: micro-proxy
   labels:
-    micro: service
+    micro: runtime
     name: micro-proxy
 spec:
   replicas: 3
   selector:
     matchLabels:
       name: micro-proxy
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-proxy
-        micro: service
+        micro: runtime
     spec:
       containers:
       - name: proxy

--- a/network/config/kubernetes/services/micro/registry-svc.yaml
+++ b/network/config/kubernetes/services/micro/registry-svc.yaml
@@ -5,11 +5,11 @@ metadata:
   namespace: default
   labels:
     name: micro-registry
-    micro: service
+    micro: runtime
 spec:
   ports:
   - port: 8000
     protocol: TCP
   selector:
     name: micro-registry
-    micro: service
+    micro: runtime

--- a/network/config/kubernetes/services/micro/registry.yaml
+++ b/network/config/kubernetes/services/micro/registry.yaml
@@ -4,19 +4,19 @@ metadata:
   namespace: default
   name: micro-registry
   labels:
-    micro: service
+    micro: runtime
     name: micro-registry
 spec:
   replicas: 3
   selector:
     matchLabels:
       name: micro-registry
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-registry
-        micro: service
+        micro: runtime
     spec:
       containers:
       - name: registry

--- a/network/config/kubernetes/services/micro/router-svc.yaml
+++ b/network/config/kubernetes/services/micro/router-svc.yaml
@@ -5,11 +5,11 @@ metadata:
   namespace: default
   labels:
     name: micro-router
-    micro: service
+    micro: runtime
 spec:
   ports:
   - port: 8084
     protocol: TCP
   selector:
     name: micro-router
-    micro: service
+    micro: runtime

--- a/network/config/kubernetes/services/micro/router.yaml
+++ b/network/config/kubernetes/services/micro/router.yaml
@@ -4,19 +4,19 @@ metadata:
   namespace: default
   name: micro-router
   labels:
-    micro: service
+    micro: runtime
     name: micro-router
 spec:
   replicas: 3
   selector:
     matchLabels:
       name: micro-router
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-router
-        micro: service
+        micro: runtime
     spec:
       containers:
       - name: router

--- a/network/config/kubernetes/services/micro/runtime.yaml
+++ b/network/config/kubernetes/services/micro/runtime.yaml
@@ -50,19 +50,19 @@ metadata:
   namespace: default
   name: micro-runtime
   labels:
-    micro: service
+    micro: runtime
     name: micro-runtime
 spec:
   replicas: 1
   selector:
     matchLabels:
       name: micro-runtime
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-runtime
-        micro: service
+        micro: runtime
     spec:
       serviceAccountName: micro-runtime
       containers:

--- a/network/config/kubernetes/services/micro/tunnel-svc.yaml
+++ b/network/config/kubernetes/services/micro/tunnel-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     name: micro-tunnel
-    micro: service
+    micro: runtime
 spec:
   type: NodePort
   ports:
@@ -14,4 +14,4 @@ spec:
     nodePort: 30036
   selector:
     name: micro-tunnel
-    micro: service
+    micro: runtime

--- a/network/config/kubernetes/services/micro/tunnel.yaml
+++ b/network/config/kubernetes/services/micro/tunnel.yaml
@@ -4,19 +4,19 @@ metadata:
   namespace: default
   name: micro-tunnel
   labels:
-    micro: service
+    micro: runtime
     name: micro-tunnel
 spec:
   replicas: 3
   selector:
     matchLabels:
       name: micro-tunnel
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-tunnel
-        micro: service
+        micro: runtime
     spec:
       containers:
       - name: tunnel

--- a/network/config/kubernetes/services/micro/web-svc.yaml
+++ b/network/config/kubernetes/services/micro/web-svc.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: default
   labels:
     name: micro-web
-    micro: service
+    micro: runtime
 spec:
   ports:
   - name: https
@@ -13,5 +13,5 @@ spec:
     targetPort: 443
   selector:
     name: micro-web
-    micro: service
+    micro: runtime
   type: LoadBalancer

--- a/network/config/kubernetes/services/micro/web.yaml
+++ b/network/config/kubernetes/services/micro/web.yaml
@@ -4,19 +4,19 @@ metadata:
   namespace: default
   name: micro-web
   labels:
-    micro: service
+    micro: runtime
     name: micro-web
 spec:
   replicas: 1
   selector:
     matchLabels:
       name: micro-web
-      micro: service
+      micro: runtime
   template:
     metadata:
       labels:
         name: micro-web
-        micro: service
+        micro: runtime
     spec:
       containers:
       - name: web

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -114,7 +114,6 @@ func runService(ctx *cli.Context, srvOpts ...micro.Option) {
 		Name:     name,
 		Source:   source,
 		Version:  version,
-		Exec:     exec,
 		Metadata: make(map[string]string),
 	}
 
@@ -132,6 +131,7 @@ func runService(ctx *cli.Context, srvOpts ...micro.Option) {
 	// runtime based on environment we run the service in
 	// TODO: how will this work with runtime service
 	opts := []runtime.CreateOption{
+		runtime.WithCommand(exec...),
 		runtime.WithOutput(os.Stdout),
 		runtime.WithEnv(environment),
 	}
@@ -202,6 +202,7 @@ func getService(ctx *cli.Context, srvOpts ...micro.Option) {
 	name := ctx.String("name")
 	version := ctx.String("version")
 	local := ctx.Bool("local")
+	runType := ctx.Bool("runtime")
 
 	var r runtime.Runtime
 	switch local {
@@ -212,6 +213,7 @@ func getService(ctx *cli.Context, srvOpts ...micro.Option) {
 	}
 
 	var list bool
+
 	if len(ctx.Args()) == 0 || ctx.Args()[1] != "service" {
 		list = true
 	}
@@ -219,28 +221,47 @@ func getService(ctx *cli.Context, srvOpts ...micro.Option) {
 	var services []*runtime.Service
 	var err error
 
+	// return a list of services
 	switch list {
 	case true:
-		// list all running services
-		services, err = r.List()
-		if err != nil {
-			log.Fatal(err)
+		// return the runtiem services
+		if runType {
+			services, err = r.Read(runtime.ReadType("runtime"))
+		} else {
+			// list all running services
+			services, err = r.List()
 		}
+	// return one service
 	default:
+		// check if service name was passed in
 		if len(name) == 0 {
 			log.Fatal(GetUsage)
 		}
-		// query runtime for named service status
-		services, err = r.Read(name, runtime.WithVersion(version))
-		if err != nil {
-			log.Fatal(err)
+
+		// get service with name and version
+		opts := []runtime.ReadOption{
+			runtime.ReadService(name),
+			runtime.ReadVersion(version),
 		}
+
+		// return the runtime services
+		if runType {
+			opts = append(opts, runtime.ReadType("runtime"))
+		}
+
+		// read the service
+		services, err = r.Read(opts...)
+	}
+
+	// check the error
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	// make sure we return UNKNOWN when empty string is supplied
 	parse := func(m string) string {
 		if len(m) == 0 {
-			return "UNKNOWN"
+			return "n/a"
 		}
 		return m
 	}
@@ -342,6 +363,10 @@ func Flags() []cli.Flag {
 		cli.StringSliceFlag{
 			Name:  "env",
 			Usage: "Set the environment variables e.g. foo=bar",
+		},
+		cli.BoolFlag{
+			Name:  "runtime",
+			Usage: "Return the runtime services",
 		},
 	}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -76,7 +76,7 @@ func run(ctx *cli.Context, opts ...micro.Option) {
 	// run the service if asked to
 	if len(ctx.Args()) > 0 {
 		args := []runtime.CreateOption{
-			runtime.WithCommand(ctx.Args()[0], ctx.Args()[1:]...),
+			runtime.WithCommand(ctx.Args()...),
 			runtime.WithOutput(os.Stdout),
 		}
 


### PR DESCRIPTION
This PR changes core services to be of type "runtime". What we onced called the toolkit is now referred to as the micro runtime. This is overloaded with the micro runtime service but then again all things are overloaded terms.

Micro Runtime references this repository and the services provided within it. The Micro Runtime is a microservice development runtime and the things it manages are "services". or "micro services" (space optional).