### PR TITLE
Disable cgo for netdata image

### DIFF
--- a/network/config/kubernetes/services/infra/netdata/Dockerfile
+++ b/network/config/kubernetes/services/infra/netdata/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /tmp/build
 RUN git clone https://github.com/jakexks/go.d.plugin
 WORKDIR /tmp/build/go.d.plugin
 RUN git checkout gomicro
+ENV CGO_ENABLED 0
 RUN go build ./cmd/godplugin
 
 FROM netdata/netdata:latest


### PR DESCRIPTION
The custom plugin failed inside the official netdata image as it uses alpine, but the golang builder image uses libc