### PR TITLE
Switch to loadbalanced UDP for the network service

### DIFF
--- a/network/config/kubernetes/azure-aks.json
+++ b/network/config/kubernetes/azure-aks.json
@@ -27,8 +27,7 @@
         "count": 3,
         "vmSize": "Standard_A2_v2",
         "availabilityProfile": "VirtualMachineScaleSets",
-        "availabilityZones": ["1", "2", "3"],
-        "enableVMSSNodePublicIP": true
+        "availabilityZones": ["1", "2", "3"]
       }
     ],
     "linuxProfile": {

--- a/network/config/kubernetes/azure-aks.json
+++ b/network/config/kubernetes/azure-aks.json
@@ -1,48 +1,49 @@
 {
-    "apiVersion": "vlabs",
-    "properties": {
-      "orchestratorProfile": {
-        "orchestratorType": "Kubernetes",
-        "orchestratorRelease": "1.13",
-        "kubernetesConfig": {
-          "networkPlugin": "azure",
-          "containerRuntime": "containerd",
-          "addons": [
-            {
-              "name": "kubernetes-dashboard",
-              "enabled" : false
-            }
-          ]
-        }
-      },
-      "masterProfile": {
-        "count": 1,
-        "dnsPrefix": "",
-        "vmSize": "Standard_A2_v2"
-      },
-      "agentPoolProfiles": [
-        {
-          "name": "workers",
-          "count": 3,
-          "vmSize": "Standard_A2_v2",
-          "availabilityProfile": "VirtualMachineScaleSets",
-          "enableVMSSNodePublicIP": true
-        }
-      ],
-      "linuxProfile": {
-        "adminUsername": "azureuser",
-        "ssh": {
-          "publicKeys": [
-            {
-              "keyData": ""
-            }
-          ]
-        }
-      },
-      "servicePrincipalProfile": {
-        "clientId": "",
-        "secret": ""
+  "apiVersion": "vlabs",
+  "properties": {
+    "orchestratorProfile": {
+      "orchestratorType": "Kubernetes",
+      "orchestratorRelease": "1.13",
+      "kubernetesConfig": {
+        "networkPlugin": "azure",
+        "addons": [
+          {
+            "name": "kubernetes-dashboard",
+            "enabled": false
+          }
+        ]
       }
+    },
+    "masterProfile": {
+      "count": 3,
+      "dnsPrefix": "",
+      "vmSize": "Standard_A2_v2",
+      "availabilityProfile": "VirtualMachineScaleSets",
+      "availabilityZones": ["1", "2", "3"]
+    },
+    "agentPoolProfiles": [
+      {
+        "name": "workers",
+        "count": 3,
+        "vmSize": "Standard_A2_v2",
+        "availabilityProfile": "VirtualMachineScaleSets",
+        "availabilityZones": ["1", "2", "3"],
+        "enableVMSSNodePublicIP": true
+      }
+    ],
+    "linuxProfile": {
+      "adminUsername": "azureuser",
+      "ssh": {
+        "publicKeys": [
+          {
+            "keyData": ""
+          }
+        ]
+      }
+    },
+    "servicePrincipalProfile": {
+      "clientId": "",
+      "secret": ""
     }
   }
-  
+}

--- a/network/config/kubernetes/services/micro/network-svc.yaml
+++ b/network/config/kubernetes/services/micro/network-svc.yaml
@@ -7,12 +7,12 @@ metadata:
     name: micro-network
     micro: runtime
 spec:
-  type: NodePort
+  type: LoadBalancer
   ports:
   - port: 8085
     protocol: UDP
     name: network
-    nodePort: 30038
+    targetPort: 8085
   selector:
     name: micro-network
     micro: runtime

--- a/network/config/kubernetes/services/micro/network.yaml
+++ b/network/config/kubernetes/services/micro/network.yaml
@@ -63,7 +63,7 @@ spec:
         - name: MICRO_SERVER_ADDRESS
           value: "0.0.0.0:8080"
         - name: MICRO_NETWORK_NODES
-          value: "network.micro.mu:30038"
+          value: "network.micro.mu"
         - name: MICRO_NETWORK_SVC_NODE_PORT
           value: "8085"
         - name: MICRO_NETWORK_DNS_REMOVE_DOMAIN

--- a/network/config/kubernetes/services/micro/network.yaml
+++ b/network/config/kubernetes/services/micro/network.yaml
@@ -65,7 +65,7 @@ spec:
         - name: MICRO_NETWORK_NODES
           value: "network.micro.mu:30038"
         - name: MICRO_NETWORK_SVC_NODE_PORT
-          value: "30038"
+          value: "8085"
         - name: MICRO_NETWORK_DNS_REMOVE_DOMAIN
           value: "network.micro.mu"
         - name: MICRO_NETWORK_DNS_REMOVE_TOKEN
@@ -94,26 +94,13 @@ spec:
         - containerPort: 8085
           name: network-port
           protocol: UDP
-        lifecycle:
-          preStop:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - /micro network dns remove --address $(cat /node_info/ip)
-          postStart:
-            exec:
-              command:
-              - /bin/sh
-              - -c
-              - /micro network dns advertise --address $(cat /node_info/ip)
       initContainers:
       - name: init-network-env
         env:
-        - name: NODE_NAME
+        - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
-              fieldPath: spec.nodeName
+              fieldPath: metadata.namespace
         image: microhq/curljq
         imagePullPolicy: Always
         volumeMounts:
@@ -121,5 +108,5 @@ spec:
           mountPath: /node_info
         command: ['sh', '-c']
         args:
-        - "TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token); curl -k -X GET -H \"Authorization: Bearer $TOKEN\" https://$KUBERNETES_SERVICE_HOST/api/v1/nodes/$NODE_NAME | jq -r '.status.addresses[] | select (.type==\"ExternalIP\").address' > /node_info/ip"
+        - "TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token); curl -k -X GET -H \"Authorization: Bearer $TOKEN\" https://$KUBERNETES_SERVICE_HOST/api/v1/namespaces/$POD_NAMESPACE/services/micro-network | jq -r 'if .status.loadBalancer.ingress[0].hostname != null then .status.loadBalancer.ingress[0].hostname else .status.loadBalancer.ingress[0].ip end' > /node_info/ip"
 

--- a/network/config/kubernetes/services/micro/rbac-node-reader.yaml
+++ b/network/config/kubernetes/services/micro/rbac-node-reader.yaml
@@ -5,7 +5,7 @@ metadata:
   name: node-reader
 rules:
 - apiGroups: [""]
-  resources: ["nodes"]
+  resources: ["nodes", "services"]
   verbs: ["get", "watch", "list"]
 
 ---


### PR DESCRIPTION
As Azure doesn't support multi-AZ public IP nodes in Azure AKS, we should switch to a UDP load balancer service for `micro-network`

This means that DigitalOcean deployment becomes a snowflake, so we will have to redeploy our global network with this in mind (and fix the dns for network.micro.mu by hand). However, it probably makes things easier in the long run.