### PR TITLE
Reduce docker image by binary file size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM golang:1.13-alpine as builder
-RUN apk --no-cache add make git gcc libtool musl-dev
+RUN apk --no-cache add make git gcc libtool musl-dev upx
 WORKDIR /
 COPY . /
-RUN make build
+RUN make build && upx micro
 
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates && \
-    rm -rf /var/cache/apk/* /tmp/*
-COPY --from=builder /micro .
-ENTRYPOINT ["/micro"]
+
+RUN apk add ca-certificates && \
+    rm -rf /var/cache/apk/* /tmp/* && \
+    [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
+
+COPY --from=builder /micro /usr/bin/micro
+ENTRYPOINT ["/usr/bin/micro"]

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,7 @@ vendor:
 	go mod vendor
 
 build:
-	go get
-	go build -a -installsuffix cgo -ldflags "-w ${LDFLAGS}" -o $(NAME) ./*.go
+	go build -a -installsuffix cgo -ldflags "-s -w ${LDFLAGS}" -o $(NAME)
 
 docker:
 	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) .


### PR DESCRIPTION
To reduce the overall docker image size I have compressed the binary
size with the help of upx. I have not executed `--brute` as this results
in an unusable binary. The image size gets decreased from 50MB down to
20MB.

Beside that I'm creating an nsswitch.conf file to make sure the Go
binary properly handles name resolution, for further reference to that
you can read up on
https://giedrius.blog/2018/11/22/etc-nsswitch-conf-and-etc-hosts-woes-with-the-alpine-and-others-docker-image-and-golang/.