### PR TITLE
Integrate upx into goreleaser and GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           go-version: '1.13'
       -
+        name: Install upx
+        run: sudo apt install upx -y
+      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.github/workflows/upx.sh
+++ b/.github/workflows/upx.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+for FILE in dist/micro_*/*; do
+    du -sh ${FILE}
+    upx ${FILE}
+    du -sh ${FILE}
+done

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,7 @@ builds:
   env:
     - CGO_ENABLED=0
     - GO111MODULE=on
-  ldflags: -w -X github.com/micro/micro/cmd.GitCommit={{ .ShortCommit }} -X github.com/micro/micro/cmd.GitTag={{ .Tag }} -X github.com/micro/micro/cmd.BuildDate={{ .Timestamp }}
+  ldflags: -s -w -X github.com/micro/micro/cmd.GitCommit={{ .ShortCommit }} -X github.com/micro/micro/cmd.GitTag={{ .Tag }} -X github.com/micro/micro/cmd.BuildDate={{ .Timestamp }}
   goos:
   - linux
   - darwin
@@ -23,6 +23,8 @@ builds:
   - arm64
   goarm:
   - 7
+  hooks:
+    post: .github/workflows/upx.sh
 archives:
 - name_template: '{{.ProjectName}}-{{.Tag}}-{{.Os}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}'
   replacements:


### PR DESCRIPTION
The previously integrated optimizations for the binary size should also
be included into goreleaser and the GitHub actions.