### PR TITLE
Updated proto template to allow for importing from other proto files

### DIFF
--- a/internal/template/proto.go
+++ b/internal/template/proto.go
@@ -5,6 +5,8 @@ var (
 
 package {{.FQDN}};
 
+option go_package = "{{.Dir}}/proto/{{.Alias}}";
+
 service {{title .Alias}} {
 	rpc Call(Request) returns (Response) {}
 }


### PR DESCRIPTION
One issue I've run into a few times is wanting to import messages from other protobuf files in a different service. To import files, one needs to add `go_package` option. Simple PR to add the option to the template. 

An alternative is adding another `cli.BoolFlag` at `new/new.go` for `"--go_package"`. I can PR this change if it is preferred, but I have been using go_package constantly; I'm not sure if others have been running into this.