### PR TITLE
Update 'Getting Started' example to use service in namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ micro run example --local
 micro list services
 
 # call a service
-micro call go.micro.srv.example Example.Call '{"name": "John"}'
+micro call go.micro.service.example Example.Call '{"name": "John"}'
 ```
 
 ## Usage


### PR DESCRIPTION
Update 'Getting Started' examples namespace to use `service` rather than `srv`