### PR TITLE
Proto Mod

### DIFF
--- a/scripts/protoc.sh
+++ b/scripts/protoc.sh
@@ -17,6 +17,20 @@ which protoc-gen-go
 
 MOD=Mgithub.com/micro/go-micro/api/proto/api.proto=github.com/micro/go-micro/v2/api/proto
 
+# modify the proto paths
+function modify_paths() {
+	while read line; do
+		while read path; do 
+			m=`echo $path | sed -e 's@go-micro/@go-micro/v2/@g' -e 's@/[a-z]*\.proto$@@g'`
+			MOD="${MOD},M${path}=$m"
+		done < <(grep "github.com/micro/go-micro/.*\.proto" $line | sed -e 's/^import //g' -e 's/;$//g' -e 's/"//g')
+	done < <(find . -name "*.proto")
+}
+
+modify_paths
+echo Modes $MOD
+##Mgithub.com/micro/go-micro/api/proto/api.proto=github.com/micro/go-micro/v2/api/proto
+
 echo "Building protobuf code..."
 DIR=`pwd`
 SRCDIR=$GOPATH/src

--- a/scripts/protoc.sh
+++ b/scripts/protoc.sh
@@ -28,7 +28,7 @@ function modify_paths() {
 }
 
 modify_paths
-echo Modes $MOD
+echo Modifiers used: $MOD
 ##Mgithub.com/micro/go-micro/api/proto/api.proto=github.com/micro/go-micro/v2/api/proto
 
 echo "Building protobuf code..."

--- a/scripts/protoc.sh
+++ b/scripts/protoc.sh
@@ -15,11 +15,19 @@ echo "Checking dependencies..."
 which protoc
 which protoc-gen-go
 
+MOD=Mgithub.com/micro/go-micro/api/proto/api.proto=github.com/micro/go-micro/v2/api/proto
+
 echo "Building protobuf code..."
 DIR=`pwd`
-SRCDIR=`cd $DIR && cd ../../.. && pwd`
+SRCDIR=$GOPATH/src
+
+echo "DIR $DIR"
+echo "SRCDIR $SRCDIR"
 find $DIR/proto -name '*.pb.go' -exec rm {} \;
+find $DIR/proto -name '*.micro.go' -exec rm {} \;
 find $DIR/proto -name '*.proto' -exec echo {} \;
-find $DIR/proto -name '*.proto' -exec protoc -I$SRCDIR --go_out=plugins=micro:${SRCDIR} {} \;
+find $DIR/proto -name '*.proto' -exec protoc --proto_path=$SRCDIR --micro_out=${MOD}:${SRCDIR} --go_out=${MOD}:${SRCDIR} {} \;
+#find $DIR/proto -name '*.proto' -exec protoc --proto_path=$SRCDIR --micro_out=${SRCDIR} --go_out=${SRCDIR} {} \;
+#find $DIR/proto -name '*.proto' -exec protoc --proto_path=$SRCDIR --micro_out=${SRCDIR}:${MOD} --go_out=plugins=grpc:${SRCDIR} {} \;
 
 echo "Complete"


### PR DESCRIPTION
Protoc-gen-micro is not go module aware. Import paths for things that are v2 are not set in the imports in the go files themselves. This script finds anything in go-micro and converts to a v2 path with proto modifiers.