### PR TITLE
Auth Resolver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,3 +50,5 @@ require (
 	gopkg.in/olivere/elastic.v5 v5.0.83
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )
+
+replace github.com/micro/go-micro/v2 => ../go-micro

--- a/go.mod
+++ b/go.mod
@@ -50,5 +50,3 @@ require (
 	gopkg.in/olivere/elastic.v5 v5.0.83
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )
-
-replace github.com/micro/go-micro/v2 => ../go-micro

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,12 @@ github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTM
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible/go.mod h1:qf9acutJ8cwBUhm1bqgz6Bei9/C/c93FPDljKWwsOgM=
+github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah2I+gwHF8xmJWRjooY+5248k6m4A0=
+github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
+github.com/gobwas/pool v0.2.0 h1:QEmUOlnSjWtnpRGHF3SauEiOsy82Cup83Vf2LcMlnc8=
+github.com/gobwas/pool v0.2.0/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
+github.com/gobwas/ws v1.0.3 h1:ZOigqf7iBxkA4jdQ3am7ATzdlOFp9YzA6NmuvEEZc9g=
+github.com/gobwas/ws v1.0.3/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
 github.com/godbus/dbus v0.0.0-20190422162347-ade71ed3457e/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/web/resolver.go
+++ b/web/resolver.go
@@ -58,11 +58,13 @@ func (r *resolver) Resolve(req *http.Request) (*res.Endpoint, error) {
 		}
 
 		if !re.MatchString(parts[1]) {
-			return nil, errors.New("invalid path")
+			return nil, res.ErrInvalidPath
 		}
 
 		next, err := r.Selector.Select(r.Namespace + "." + parts[1])
-		if err != nil {
+		if err == selector.ErrNotFound {
+			return nil, res.ErrNotFound
+		} else if err != nil {
 			return nil, err
 		}
 
@@ -129,7 +131,9 @@ func (r *resolver) Resolve(req *http.Request) (*res.Endpoint, error) {
 
 		// get namespace + subdomain
 		next, err := r.Selector.Select(name)
-		if err != nil {
+		if err == selector.ErrNotFound {
+			return nil, res.ErrNotFound
+		} else if err != nil {
 			return nil, err
 		}
 

--- a/web/resolver.go
+++ b/web/resolver.go
@@ -72,18 +72,12 @@ func (r *resolver) Resolve(req *http.Request) (*res.Endpoint, error) {
 			return nil, err
 		}
 
-		req.Header.Set(BasePathHeader, "/"+parts[1])
-		req.URL.Host = s.Address
-		req.URL.Path = "/" + strings.Join(parts[2:], "/")
-		req.URL.Scheme = "http"
-		req.Host = req.URL.Host
-
 		// we're done
 		return &res.Endpoint{
 			Name:   parts[1],
 			Method: req.Method,
-			Host:   req.URL.Host,
-			Path:   req.URL.Path,
+			Host:   s.Address,
+			Path:   "/" + strings.Join(parts[2:], "/"),
 		}, nil
 	}
 
@@ -145,16 +139,11 @@ func (r *resolver) Resolve(req *http.Request) (*res.Endpoint, error) {
 			return nil, err
 		}
 
-		req.Header.Set(BasePathHeader, "/")
-		req.URL.Host = s.Address
-		req.URL.Scheme = "http"
-		req.Host = req.URL.Host
-
 		// we're done
 		return &res.Endpoint{
 			Name:   alias,
 			Method: req.Method,
-			Host:   req.URL.Host,
+			Host:   s.Address,
 			Path:   req.URL.Path,
 		}, nil
 	}

--- a/web/web.go
+++ b/web/web.go
@@ -2,7 +2,6 @@
 package web
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -230,11 +229,8 @@ func (s *srv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// mark as resolved
-	ctx := context.WithValue(r.Context(), "resolved", true)
-
 	// otherwise serve the proxy
-	s.prx.ServeHTTP(w, r.WithContext(ctx))
+	s.prx.ServeHTTP(w, r)
 }
 
 // proxy is a http reverse proxy
@@ -246,12 +242,6 @@ func (s *srv) proxy() *proxy {
 			r.URL.Scheme = ""
 			r.Host = ""
 			r.RequestURI = ""
-		}
-
-		// check if we're already resolved
-		v, ok := r.Context().Value("resolved").(bool)
-		if ok && v == true {
-			return
 		}
 
 		// TODO: better error handling

--- a/web/web.go
+++ b/web/web.go
@@ -219,7 +219,13 @@ func (s *srv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// now try resolve
-	if _, err := s.resolver.Resolve(r); err != nil {
+	if endpoint, err := s.resolver.Resolve(r); err != nil {
+		r.Header.Set(BasePathHeader, "/"+endpoint.Name)
+		r.URL.Host = endpoint.Host
+		r.URL.Path = endpoint.Path
+		r.URL.Scheme = "http"
+		r.Host = r.URL.Host
+
 		s.Router.ServeHTTP(w, r)
 		return
 	}
@@ -249,11 +255,18 @@ func (s *srv) proxy() *proxy {
 		}
 
 		// TODO: better error handling
-		if _, err := s.resolver.Resolve(r); err != nil {
+		endpoint, err := s.resolver.Resolve(r)
+		if err != nil {
 			fmt.Printf("Failed to resolve url: %v: %v\n", r.URL, err)
 			kill()
 			return
 		}
+
+		r.Header.Set(BasePathHeader, "/"+endpoint.Name)
+		r.URL.Host = endpoint.Host
+		r.URL.Path = endpoint.Path
+		r.URL.Scheme = "http"
+		r.Host = r.URL.Host
 	}
 
 	return &proxy{
@@ -623,17 +636,7 @@ func run(ctx *cli.Context, srvOpts ...micro.Option) {
 	}
 
 	// pass namespace and resolver through to the server as these are needed to perform auth
-	// TODO: DEBUG WHY WE HAVE TO PASS A NEW INSTANCE OF RESOLVER AND NOT A REFERENCE
-	// srv := httpapi.NewServer(Address, server.Namespace(Namespace), server.Resolver(s.resolver))
-	srv := httpapi.NewServer(Address, server.Namespace(Namespace), server.Resolver(&resolver{
-		// Default to type path
-		Type:      Resolver,
-		Namespace: Namespace,
-		Selector: selector.NewSelector(
-			selector.Registry(reg),
-		),
-	}))
-
+	srv := httpapi.NewServer(Address, server.Namespace(Namespace), server.Resolver(s.resolver))
 	srv.Init(opts...)
 	srv.Handle("/", h)
 


### PR DESCRIPTION
Refactor web resolver to implement the api resolver interface, pass this and the namespace to the server so it can be used for auth.

Depends on: https://github.com/micro/go-micro/pull/1475