### PR TITLE
Runtime: Fix ignored options bug

### DIFF
--- a/service/runtime/handler/handler.go
+++ b/service/runtime/handler/handler.go
@@ -19,11 +19,7 @@ type Runtime struct {
 }
 
 func (r *Runtime) Read(ctx context.Context, req *pb.ReadRequest, rsp *pb.ReadResponse) error {
-	var options []runtime.ReadOption
-
-	if req.Options != nil {
-		options = toReadOptions(ctx, req.Options)
-	}
+	options := toReadOptions(ctx, req.Options)
 
 	services, err := r.Runtime.Read(options...)
 	if err != nil {


### PR DESCRIPTION
The context wasn't being parsed on runtime.Read when options were nil. `toReadOptions` handles nil options so the check in the handler is not required.