### PR TITLE
Fix terraform namespace race condition

### DIFF
--- a/platform/kubernetes/micro-platform/api.tf
+++ b/platform/kubernetes/micro-platform/api.tf
@@ -43,7 +43,7 @@ module "api_cert" {
 resource "kubernetes_secret" "api_cert" {
   metadata {
     name        = "${replace(local.api_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.api_labels
     annotations = local.api_annotations
   }
@@ -57,7 +57,7 @@ resource "kubernetes_secret" "api_cert" {
 resource "kubernetes_deployment" "api" {
   metadata {
     name        = replace(local.api_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.api_labels
     annotations = local.api_annotations
   }
@@ -147,7 +147,7 @@ resource "kubernetes_deployment" "api" {
 resource "kubernetes_service" "api" {
   metadata {
     name        = replace(local.api_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.api_labels
     annotations = local.api_annotations
   }

--- a/platform/kubernetes/micro-platform/auth-api.tf
+++ b/platform/kubernetes/micro-platform/auth-api.tf
@@ -34,7 +34,7 @@ module "auth_api_cert" {
 resource "kubernetes_secret" "auth_api_cert" {
   metadata {
     name        = "${replace(local.auth_api_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.auth_api_labels
     annotations = local.auth_api_annotations
   }
@@ -48,7 +48,7 @@ resource "kubernetes_secret" "auth_api_cert" {
 resource "kubernetes_deployment" "auth_api" {
   metadata {
     name        = replace(local.auth_api_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.auth_api_labels
     annotations = local.auth_api_annotations
   }
@@ -123,7 +123,7 @@ resource "kubernetes_deployment" "auth_api" {
 resource "kubernetes_service" "auth_api" {
   metadata {
     name        = replace(local.auth_api_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.auth_api_labels
     annotations = local.auth_api_annotations
   }

--- a/platform/kubernetes/micro-platform/auth.tf
+++ b/platform/kubernetes/micro-platform/auth.tf
@@ -34,7 +34,7 @@ module "auth_cert" {
 resource "kubernetes_secret" "auth_cert" {
   metadata {
     name        = "${replace(local.auth_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.auth_labels
     annotations = local.auth_annotations
   }
@@ -48,7 +48,7 @@ resource "kubernetes_secret" "auth_cert" {
 resource "kubernetes_deployment" "auth" {
   metadata {
     name        = replace(local.auth_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.auth_labels
     annotations = local.auth_annotations
   }
@@ -132,7 +132,7 @@ resource "kubernetes_deployment" "auth" {
 resource "kubernetes_service" "auth" {
   metadata {
     name        = replace(local.auth_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.auth_labels
     annotations = local.auth_annotations
   }

--- a/platform/kubernetes/micro-platform/bot.tf
+++ b/platform/kubernetes/micro-platform/bot.tf
@@ -33,7 +33,7 @@ module "bot_cert" {
 resource "kubernetes_secret" "bot_cert" {
   metadata {
     name        = "${replace(local.bot_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.bot_labels
     annotations = local.bot_annotations
   }
@@ -47,7 +47,7 @@ resource "kubernetes_secret" "bot_cert" {
 resource "kubernetes_deployment" "bot" {
   metadata {
     name        = replace(local.bot_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.bot_labels
     annotations = local.bot_annotations
   }

--- a/platform/kubernetes/micro-platform/broker.tf
+++ b/platform/kubernetes/micro-platform/broker.tf
@@ -34,7 +34,7 @@ module "broker_cert" {
 resource "kubernetes_secret" "broker_cert" {
   metadata {
     name        = "${replace(local.broker_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.broker_labels
     annotations = local.broker_annotations
   }
@@ -48,7 +48,7 @@ resource "kubernetes_secret" "broker_cert" {
 resource "kubernetes_deployment" "broker" {
   metadata {
     name        = replace(local.broker_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.broker_labels
     annotations = local.broker_annotations
   }
@@ -132,7 +132,7 @@ resource "kubernetes_deployment" "broker" {
 resource "kubernetes_service" "broker" {
   metadata {
     name        = replace(local.broker_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.broker_labels
     annotations = local.broker_annotations
   }

--- a/platform/kubernetes/micro-platform/config.tf
+++ b/platform/kubernetes/micro-platform/config.tf
@@ -35,7 +35,7 @@ module "config_cert" {
 resource "kubernetes_secret" "config_cert" {
   metadata {
     name        = "${replace(local.config_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.config_labels
     annotations = local.config_annotations
   }
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "config_cert" {
 resource "kubernetes_deployment" "config" {
   metadata {
     name        = replace(local.config_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.config_labels
     annotations = local.config_annotations
   }
@@ -133,7 +133,7 @@ resource "kubernetes_deployment" "config" {
 resource "kubernetes_service" "config" {
   metadata {
     name        = replace(local.config_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.config_labels
     annotations = local.config_annotations
   }

--- a/platform/kubernetes/micro-platform/debug.tf
+++ b/platform/kubernetes/micro-platform/debug.tf
@@ -35,7 +35,7 @@ module "debug_cert" {
 resource "kubernetes_secret" "debug_cert" {
   metadata {
     name        = "${replace(local.debug_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.debug_labels
     annotations = local.debug_annotations
   }
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "debug_cert" {
 resource "kubernetes_deployment" "debug" {
   metadata {
     name        = replace(local.debug_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.debug_labels
     annotations = local.debug_annotations
   }

--- a/platform/kubernetes/micro-platform/init.tf
+++ b/platform/kubernetes/micro-platform/init.tf
@@ -34,7 +34,7 @@ module "init_cert" {
 resource "kubernetes_secret" "init_cert" {
   metadata {
     name        = "${replace(local.init_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.init_labels
     annotations = local.init_annotations
   }
@@ -48,7 +48,7 @@ resource "kubernetes_secret" "init_cert" {
 resource "kubernetes_deployment" "init" {
   metadata {
     name        = replace(local.init_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.init_labels
     annotations = local.init_annotations
   }
@@ -111,7 +111,7 @@ resource "kubernetes_deployment" "init" {
 resource "kubernetes_service_account" "init" {
   metadata {
     name        = replace(local.init_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.init_labels
     annotations = local.init_annotations
   }
@@ -158,7 +158,7 @@ resource "kubernetes_cluster_role" "init" {
 resource "kubernetes_role_binding" "init" {
   metadata {
     name        = "${replace(local.init_name, ".", "-")}-${random_id.init.hex}"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.init_labels
     annotations = local.init_annotations
   }

--- a/platform/kubernetes/micro-platform/micro.tf
+++ b/platform/kubernetes/micro-platform/micro.tf
@@ -23,14 +23,14 @@ locals {
 
 resource "kubernetes_namespace" "platform" {
   metadata {
-    name = var.platform_namespace
+    name = kubernetes_namespace.platform.id
   }
 }
 
 resource "kubernetes_secret" "cloudflare_credentals" {
   metadata {
     name        = "cloudflare-credentials"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.common_labels
     annotations = local.common_annotations
   }
@@ -42,7 +42,7 @@ resource "kubernetes_secret" "cloudflare_credentals" {
 resource "kubernetes_secret" "micro_keypair" {
   metadata {
     name        = "micro-keypair"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.common_labels
     annotations = local.common_annotations
   }
@@ -55,7 +55,7 @@ resource "kubernetes_secret" "micro_keypair" {
 resource "kubernetes_secret" "platform_ca" {
   metadata {
     name        = "platform-ca"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.common_labels
     annotations = local.common_annotations
   }
@@ -67,7 +67,7 @@ resource "kubernetes_secret" "platform_ca" {
 resource "kubernetes_secret" "slack_token" {
   metadata {
     name        = "micro-slack-token"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.common_labels
     annotations = local.common_annotations
   }

--- a/platform/kubernetes/micro-platform/network.tf
+++ b/platform/kubernetes/micro-platform/network.tf
@@ -37,7 +37,7 @@ module "network_cert" {
 resource "kubernetes_secret" "network_cert" {
   metadata {
     name        = "${replace(local.network_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.network_labels
     annotations = local.network_annotations
   }
@@ -51,7 +51,7 @@ resource "kubernetes_secret" "network_cert" {
 resource "kubernetes_deployment" "network" {
   metadata {
     name        = replace(local.network_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.network_labels
     annotations = local.network_annotations
   }
@@ -122,7 +122,7 @@ resource "kubernetes_deployment" "network" {
 resource "kubernetes_service" "network" {
   metadata {
     name        = replace(local.network_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.network_labels
     annotations = local.network_annotations
   }

--- a/platform/kubernetes/micro-platform/proxy.tf
+++ b/platform/kubernetes/micro-platform/proxy.tf
@@ -45,7 +45,7 @@ module "proxy_cert" {
 resource "kubernetes_secret" "proxy_cert" {
   metadata {
     name        = "${replace(local.proxy_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.proxy_labels
     annotations = local.proxy_annotations
   }
@@ -59,7 +59,7 @@ resource "kubernetes_secret" "proxy_cert" {
 resource "kubernetes_deployment" "proxy" {
   metadata {
     name        = replace(local.proxy_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.proxy_labels
     annotations = local.proxy_annotations
   }
@@ -153,7 +153,7 @@ resource "kubernetes_deployment" "proxy" {
 resource "kubernetes_service" "proxy" {
   metadata {
     name        = replace(local.proxy_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.proxy_labels
     annotations = local.proxy_annotations
   }

--- a/platform/kubernetes/micro-platform/registry.tf
+++ b/platform/kubernetes/micro-platform/registry.tf
@@ -34,7 +34,7 @@ module "registry_cert" {
 resource "kubernetes_secret" "registry_cert" {
   metadata {
     name        = "${replace(local.registry_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.registry_labels
     annotations = local.registry_annotations
   }
@@ -48,7 +48,7 @@ resource "kubernetes_secret" "registry_cert" {
 resource "kubernetes_deployment" "registry" {
   metadata {
     name        = replace(local.registry_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.registry_labels
     annotations = local.registry_annotations
   }
@@ -132,7 +132,7 @@ resource "kubernetes_deployment" "registry" {
 resource "kubernetes_service" "registry" {
   metadata {
     name        = replace(local.registry_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.registry_labels
     annotations = local.registry_annotations
   }

--- a/platform/kubernetes/micro-platform/router.tf
+++ b/platform/kubernetes/micro-platform/router.tf
@@ -34,7 +34,7 @@ module "router_cert" {
 resource "kubernetes_secret" "router_cert" {
   metadata {
     name        = "${replace(local.router_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.router_labels
     annotations = local.router_annotations
   }
@@ -48,7 +48,7 @@ resource "kubernetes_secret" "router_cert" {
 resource "kubernetes_deployment" "router" {
   metadata {
     name        = replace(local.router_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.router_labels
     annotations = local.router_annotations
   }
@@ -132,7 +132,7 @@ resource "kubernetes_deployment" "router" {
 resource "kubernetes_service" "router" {
   metadata {
     name        = replace(local.router_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.router_labels
     annotations = local.router_annotations
   }

--- a/platform/kubernetes/micro-platform/runtime.tf
+++ b/platform/kubernetes/micro-platform/runtime.tf
@@ -36,7 +36,7 @@ module "runtime_cert" {
 resource "kubernetes_secret" "runtime_cert" {
   metadata {
     name        = "${replace(local.runtime_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.runtime_labels
     annotations = local.runtime_annotations
   }
@@ -50,7 +50,7 @@ resource "kubernetes_secret" "runtime_cert" {
 resource "kubernetes_deployment" "runtime" {
   metadata {
     name        = replace(local.runtime_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.runtime_labels
     annotations = local.runtime_annotations
   }
@@ -131,7 +131,7 @@ resource "kubernetes_deployment" "runtime" {
 resource "kubernetes_service_account" "runtime" {
   metadata {
     name        = replace(local.runtime_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.runtime_labels
     annotations = local.runtime_annotations
   }
@@ -199,7 +199,7 @@ resource "kubernetes_cluster_role_binding" "runtime" {
   subject {
     kind      = "ServiceAccount"
     name      = kubernetes_service_account.runtime.metadata[0].name
-    namespace = var.platform_namespace
+    namespace = kubernetes_namespace.platform.id
   }
   role_ref {
     api_group = "rbac.authorization.k8s.io"

--- a/platform/kubernetes/micro-platform/store.tf
+++ b/platform/kubernetes/micro-platform/store.tf
@@ -35,7 +35,7 @@ module "store_cert" {
 resource "kubernetes_secret" "store_cert" {
   metadata {
     name        = "${replace(local.store_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.store_labels
     annotations = local.store_annotations
   }
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "store_cert" {
 resource "kubernetes_deployment" "store" {
   metadata {
     name        = replace(local.store_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.store_labels
     annotations = local.store_annotations
   }

--- a/platform/kubernetes/micro-platform/web.tf
+++ b/platform/kubernetes/micro-platform/web.tf
@@ -45,7 +45,7 @@ module "web_cert" {
 resource "kubernetes_secret" "web_cert" {
   metadata {
     name        = "${replace(local.web_name, ".", "-")}-cert"
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.web_labels
     annotations = local.web_annotations
   }
@@ -59,7 +59,7 @@ resource "kubernetes_secret" "web_cert" {
 resource "kubernetes_deployment" "web" {
   metadata {
     name        = replace(local.web_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.web_labels
     annotations = merge(local.common_annotations, local.web_annotations)
   }
@@ -149,7 +149,7 @@ resource "kubernetes_deployment" "web" {
 resource "kubernetes_service" "web" {
   metadata {
     name        = replace(local.web_name, ".", "-")
-    namespace   = var.platform_namespace
+    namespace   = kubernetes_namespace.platform.id
     labels      = local.web_labels
     annotations = merge(local.common_annotations, local.web_annotations)
   }


### PR DESCRIPTION
If the namespace was later in the graph than a resource the terraform would fail to apply. This PR makes resources depend on namespaces