### PR TITLE
Validate Issuer for noop auth

### DIFF
--- a/client/api/auth/wrapper.go
+++ b/client/api/auth/wrapper.go
@@ -66,7 +66,7 @@ func (a authWrapper) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	acc, _ := a.auth.Inspect(token)
 
 	// Ensure the accounts issuer matches the namespace being requested
-	if acc != nil && acc.Issuer != ns {
+	if acc != nil && len(acc.Issuer) > 0 && acc.Issuer != ns {
 		http.Error(w, "Account not issued by "+ns, 403)
 		return
 	}


### PR DESCRIPTION
Ensure there is an Issuer on the response, in the case of the `noop` Auth, I have encountered the case where [it is empty](https://github.com/micro/go-micro/blob/master/auth/default.go#L82).

I'm walking my way down to the auth after a while not updating, if this is conceptually wrong, can someone provide an explanation?

Thanks!