### PR TITLE
Wait for status of process to change from "starting" to something else before returning on `micro run`

### DIFF
--- a/service/runtime/manager/events.go
+++ b/service/runtime/manager/events.go
@@ -100,7 +100,7 @@ func (m *manager) processEvent(key string) {
 	}
 
 	// log the event
-	logger.Infof("Procesing %v event for service %v:%v in namespace %v", ev.Type, ev.Service.Name, ev.Service.Version, ns)
+	logger.Infof("Processing %v event for service %v:%v in namespace %v", ev.Type, ev.Service.Name, ev.Service.Version, ns)
 
 	// apply the event to the managed runtime
 	switch ev.Type {
@@ -121,11 +121,10 @@ func (m *manager) processEvent(key string) {
 
 	// if there was an error update the status in the cache
 	if err != nil {
-		logger.Warnf("Error procesing %v event for service %v:%v in namespace %v: %v,", ev.Type, ev.Service.Name, ev.Service.Version, ns, err)
+		logger.Warnf("Error processing %v event for service %v:%v in namespace %v: %v", ev.Type, ev.Service.Name, ev.Service.Version, ns, err)
 		ev.Service.Metadata = map[string]string{"status": "error", "error": err.Error()}
 		m.cacheStatus(ns, ev.Service)
 	} else if ev.Type != runtime.Delete {
-		ev.Service.Metadata = map[string]string{"status": "starting"}
 		m.cacheStatus(ns, ev.Service)
 	}
 


### PR DESCRIPTION
Fixes a bug where status was always `starting`. With it now reporting the status correctly we can now wait for the status to change when running `micro run` and report back success or failure of service start.  

However, it should be noted that there is still a race condition with `micro run .` whereby if the code trying to be run does not compile the status will go `starting` -> `running` -> `error` but `micro run .` will either report success because it sees the transient `running` state OR report failure because it missing that step and sees `error`. But at least with this fix the status will eventually be reported correctly to `micro status`.
