### PR TITLE
Show help if subcommand is not recognised rather than run the core service

### DIFF
--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -66,4 +67,14 @@ func TLSConfig(ctx *cli.Context) (*tls.Config, error) {
 	}
 
 	return nil, errors.New("TLS certificate and key files not specified")
+}
+
+// UnexpectedSubcommand checks for erroneous subcommands and prints help and returns error
+func UnexpectedSubcommand(ctx *cli.Context) error {
+	if first := ctx.Args().First(); first != "" {
+		// received something that isn't a subcommand
+		cli.ShowSubcommandHelp(ctx)
+		return fmt.Errorf("Unrecognized subcommand %s", first)
+	}
+	return nil
 }

--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -224,10 +224,10 @@ func Commands(srvOpts ...micro.Option) []*cli.Command {
 			Name:  "auth",
 			Usage: "Run the auth service",
 			Action: func(ctx *cli.Context) error {
-				if ctx.Args().First() != "" {
+				if first := ctx.Args().First(); first != "" {
 					// received something that isn't a subcommand
 					cli.ShowSubcommandHelp(ctx)
-					return fmt.Errorf("Unrecognized subcommand %s", ctx.Args().First())
+					return fmt.Errorf("Unrecognized subcommand %s", first)
 				}
 				Run(ctx)
 				return nil

--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -229,6 +229,10 @@ func Commands(srvOpts ...micro.Option) []*cli.Command {
 			Name:  "auth",
 			Usage: "Run the auth service",
 			Action: func(ctx *cli.Context) error {
+				if ctx.Args().First() != "" {
+					// received something that isn't a subcommand
+					return cli.ShowAppHelp(ctx)
+				}
 				Run(ctx)
 				return nil
 			},

--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -90,11 +90,6 @@ var (
 func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 	log.Init(log.WithFields(map[string]interface{}{"service": "auth"}))
 
-	// Init plugins
-	for _, p := range Plugins() {
-		p.Init(ctx)
-	}
-
 	if len(ctx.String("address")) > 0 {
 		Address = ctx.String("address")
 	}
@@ -231,7 +226,8 @@ func Commands(srvOpts ...micro.Option) []*cli.Command {
 			Action: func(ctx *cli.Context) error {
 				if ctx.Args().First() != "" {
 					// received something that isn't a subcommand
-					return cli.ShowAppHelp(ctx)
+					cli.ShowSubcommandHelp(ctx)
+					return fmt.Errorf("Unrecognized subcommand %s", ctx.Args().First())
 				}
 				Run(ctx)
 				return nil

--- a/service/auth/auth.go
+++ b/service/auth/auth.go
@@ -19,6 +19,7 @@ import (
 	cliutil "github.com/micro/micro/v2/client/cli/util"
 	"github.com/micro/micro/v2/internal/client"
 	"github.com/micro/micro/v2/internal/config"
+	"github.com/micro/micro/v2/internal/helper"
 	"github.com/micro/micro/v2/service/auth/api"
 	authHandler "github.com/micro/micro/v2/service/auth/handler/auth"
 	rulesHandler "github.com/micro/micro/v2/service/auth/handler/rules"
@@ -224,10 +225,8 @@ func Commands(srvOpts ...micro.Option) []*cli.Command {
 			Name:  "auth",
 			Usage: "Run the auth service",
 			Action: func(ctx *cli.Context) error {
-				if first := ctx.Args().First(); first != "" {
-					// received something that isn't a subcommand
-					cli.ShowSubcommandHelp(ctx)
-					return fmt.Errorf("Unrecognized subcommand %s", first)
+				if err := helper.UnexpectedSubcommand(ctx); err != nil {
+					return err
 				}
 				Run(ctx)
 				return nil

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -199,10 +199,10 @@ func Commands(options ...micro.Option) []*cli.Command {
 			},
 		},
 		Action: func(ctx *cli.Context) error {
-			if ctx.Args().First() != "" {
+			if first := ctx.Args().First(); first != "" {
 				// received something that isn't a subcommand
 				cli.ShowSubcommandHelp(ctx)
-				return fmt.Errorf("Unrecognized subcommand %s", ctx.Args().First())
+				return fmt.Errorf("Unrecognized subcommand %s", first)
 			}
 			Run(ctx, options...)
 			return nil

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -199,6 +199,10 @@ func Commands(options ...micro.Option) []*cli.Command {
 			},
 		},
 		Action: func(ctx *cli.Context) error {
+			if ctx.Args().First() != "" {
+				// received something that isn't a subcommand
+				return cli.ShowAppHelp(ctx)
+			}
 			Run(ctx, options...)
 			return nil
 		},

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -13,6 +13,7 @@ import (
 	proto "github.com/micro/go-micro/v2/config/source/service/proto"
 	log "github.com/micro/go-micro/v2/logger"
 	"github.com/micro/micro/v2/internal/client"
+	"github.com/micro/micro/v2/internal/helper"
 	"github.com/micro/micro/v2/service/config/handler"
 )
 
@@ -199,10 +200,8 @@ func Commands(options ...micro.Option) []*cli.Command {
 			},
 		},
 		Action: func(ctx *cli.Context) error {
-			if first := ctx.Args().First(); first != "" {
-				// received something that isn't a subcommand
-				cli.ShowSubcommandHelp(ctx)
-				return fmt.Errorf("Unrecognized subcommand %s", first)
+			if err := helper.UnexpectedSubcommand(ctx); err != nil {
+				return err
 			}
 			Run(ctx, options...)
 			return nil

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -201,7 +201,8 @@ func Commands(options ...micro.Option) []*cli.Command {
 		Action: func(ctx *cli.Context) error {
 			if ctx.Args().First() != "" {
 				// received something that isn't a subcommand
-				return cli.ShowAppHelp(ctx)
+				cli.ShowSubcommandHelp(ctx)
+				return fmt.Errorf("Unrecognized subcommand %s", ctx.Args().First())
 			}
 			Run(ctx, options...)
 			return nil

--- a/service/network/network.go
+++ b/service/network/network.go
@@ -50,11 +50,6 @@ var (
 func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 	log.Init(log.WithFields(map[string]interface{}{"service": "network"}))
 
-	if ctx.Args().Len() > 0 {
-		cli.ShowSubcommandHelp(ctx)
-		os.Exit(1)
-	}
-
 	// Init plugins
 	for _, p := range Plugins() {
 		p.Init(ctx)
@@ -320,7 +315,8 @@ func Commands(options ...micro.Option) []*cli.Command {
 		Action: func(ctx *cli.Context) error {
 			if ctx.Args().First() != "" {
 				// received something that isn't a subcommand
-				return cli.ShowAppHelp(ctx)
+				cli.ShowSubcommandHelp(ctx)
+				return fmt.Errorf("Unrecognized subcommand %s", ctx.Args().First())
 			}
 			Run(ctx, options...)
 			return nil

--- a/service/network/network.go
+++ b/service/network/network.go
@@ -302,10 +302,8 @@ func Commands(options ...micro.Option) []*cli.Command {
 					},
 				},
 				Action: func(ctx *cli.Context) error {
-					if first := ctx.Args().First(); first != "" {
-						// received something that isn't a subcommand
-						cli.ShowSubcommandHelp(ctx)
-						return fmt.Errorf("Unrecognized subcommand %s", first)
+					if err := helper.UnexpectedSubcommand(ctx); err != nil {
+						return err
 					}
 					netdns.Run(ctx)
 					return nil
@@ -314,10 +312,8 @@ func Commands(options ...micro.Option) []*cli.Command {
 			},
 		}, mcli.NetworkCommands()...),
 		Action: func(ctx *cli.Context) error {
-			if first := ctx.Args().First(); first != "" {
-				// received something that isn't a subcommand
-				cli.ShowSubcommandHelp(ctx)
-				return fmt.Errorf("Unrecognized subcommand %s", first)
+			if err := helper.UnexpectedSubcommand(ctx); err != nil {
+				return err
 			}
 			Run(ctx, options...)
 			return nil

--- a/service/network/network.go
+++ b/service/network/network.go
@@ -307,6 +307,10 @@ func Commands(options ...micro.Option) []*cli.Command {
 					},
 				},
 				Action: func(ctx *cli.Context) error {
+					if ctx.Args().First() != "" {
+						// received something that isn't a subcommand
+						return cli.ShowAppHelp(ctx)
+					}
 					netdns.Run(ctx)
 					return nil
 				},
@@ -314,6 +318,10 @@ func Commands(options ...micro.Option) []*cli.Command {
 			},
 		}, mcli.NetworkCommands()...),
 		Action: func(ctx *cli.Context) error {
+			if ctx.Args().First() != "" {
+				// received something that isn't a subcommand
+				return cli.ShowAppHelp(ctx)
+			}
 			Run(ctx, options...)
 			return nil
 		},

--- a/service/network/network.go
+++ b/service/network/network.go
@@ -302,9 +302,10 @@ func Commands(options ...micro.Option) []*cli.Command {
 					},
 				},
 				Action: func(ctx *cli.Context) error {
-					if ctx.Args().First() != "" {
+					if first := ctx.Args().First(); first != "" {
 						// received something that isn't a subcommand
-						return cli.ShowAppHelp(ctx)
+						cli.ShowSubcommandHelp(ctx)
+						return fmt.Errorf("Unrecognized subcommand %s", first)
 					}
 					netdns.Run(ctx)
 					return nil
@@ -313,10 +314,10 @@ func Commands(options ...micro.Option) []*cli.Command {
 			},
 		}, mcli.NetworkCommands()...),
 		Action: func(ctx *cli.Context) error {
-			if ctx.Args().First() != "" {
+			if first := ctx.Args().First(); first != "" {
 				// received something that isn't a subcommand
 				cli.ShowSubcommandHelp(ctx)
-				return fmt.Errorf("Unrecognized subcommand %s", ctx.Args().First())
+				return fmt.Errorf("Unrecognized subcommand %s", first)
 			}
 			Run(ctx, options...)
 			return nil

--- a/service/registry/registry.go
+++ b/service/registry/registry.go
@@ -3,7 +3,6 @@ package registry
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/micro/cli/v2"
@@ -13,6 +12,7 @@ import (
 	"github.com/micro/go-micro/v2/registry/service"
 	pb "github.com/micro/go-micro/v2/registry/service/proto"
 	rcli "github.com/micro/micro/v2/client/cli"
+	"github.com/micro/micro/v2/internal/helper"
 	"github.com/micro/micro/v2/service/registry/handler"
 )
 
@@ -138,10 +138,8 @@ func Commands(options ...micro.Option) []*cli.Command {
 			},
 		},
 		Action: func(ctx *cli.Context) error {
-			if first := ctx.Args().First(); first != "" {
-				// received something that isn't a subcommand
-				cli.ShowSubcommandHelp(ctx)
-				return fmt.Errorf("Unrecognized subcommand %s", first)
+			if err := helper.UnexpectedSubcommand(ctx); err != nil {
+				return err
 			}
 			Run(ctx, options...)
 			return nil

--- a/service/registry/registry.go
+++ b/service/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/micro/cli/v2"
@@ -139,7 +140,8 @@ func Commands(options ...micro.Option) []*cli.Command {
 		Action: func(ctx *cli.Context) error {
 			if ctx.Args().First() != "" {
 				// received something that isn't a subcommand
-				return cli.ShowAppHelp(ctx)
+				cli.ShowSubcommandHelp(ctx)
+				return fmt.Errorf("Unrecognized subcommand %s", ctx.Args().First())
 			}
 			Run(ctx, options...)
 			return nil

--- a/service/registry/registry.go
+++ b/service/registry/registry.go
@@ -111,20 +111,6 @@ func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 	// get server id
 	id := service.Server().Options().Id
 
-	/*
-		// create the subscriber
-		s := &subscriber{
-			Id:       id,
-			Registry: service.Options().Registry,
-		}
-
-		// register the subscriber
-			if err := micro.RegisterSubscriber(Topic, service.Server(), s); err != nil {
-				log.Debugf("failed to subscribe to events: %s", err)
-				os.Exit(1)
-			}
-	*/
-
 	// register the handler
 	pb.RegisterRegistryHandler(service.Server(), &handler.Registry{
 		Id:        id,
@@ -151,6 +137,10 @@ func Commands(options ...micro.Option) []*cli.Command {
 			},
 		},
 		Action: func(ctx *cli.Context) error {
+			if ctx.Args().First() != "" {
+				// received something that isn't a subcommand
+				return cli.ShowAppHelp(ctx)
+			}
 			Run(ctx, options...)
 			return nil
 		},

--- a/service/registry/registry.go
+++ b/service/registry/registry.go
@@ -138,10 +138,10 @@ func Commands(options ...micro.Option) []*cli.Command {
 			},
 		},
 		Action: func(ctx *cli.Context) error {
-			if ctx.Args().First() != "" {
+			if first := ctx.Args().First(); first != "" {
 				// received something that isn't a subcommand
 				cli.ShowSubcommandHelp(ctx)
-				return fmt.Errorf("Unrecognized subcommand %s", ctx.Args().First())
+				return fmt.Errorf("Unrecognized subcommand %s", first)
 			}
 			Run(ctx, options...)
 			return nil

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -18,7 +18,7 @@ var (
 	Address = ":8002"
 )
 
-// run runs the micro server
+// Run runs the micro server
 func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 	log.Init(log.WithFields(map[string]interface{}{"service": "store"}))
 
@@ -100,6 +100,11 @@ func Commands(options ...micro.Option) []*cli.Command {
 			},
 		},
 		Action: func(ctx *cli.Context) error {
+			if ctx.Args().First() != "" {
+				// received something that isn't a subcommand
+				return cli.ShowAppHelp(ctx)
+
+			}
 			Run(ctx, options...)
 			return nil
 		},

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -1,14 +1,13 @@
 package store
 
 import (
-	"fmt"
-
 	"github.com/micro/cli/v2"
 	"github.com/micro/go-micro/v2"
 	log "github.com/micro/go-micro/v2/logger"
 	"github.com/micro/go-micro/v2/store"
 	pb "github.com/micro/go-micro/v2/store/service/proto"
 	mcli "github.com/micro/micro/v2/client/cli"
+	"github.com/micro/micro/v2/internal/helper"
 	"github.com/micro/micro/v2/service/store/handler"
 	"github.com/pkg/errors"
 )
@@ -102,10 +101,8 @@ func Commands(options ...micro.Option) []*cli.Command {
 			},
 		},
 		Action: func(ctx *cli.Context) error {
-			if first := ctx.Args().First(); first != "" {
-				// received something that isn't a subcommand
-				cli.ShowSubcommandHelp(ctx)
-				return fmt.Errorf("Unrecognized subcommand %s", first)
+			if err := helper.UnexpectedSubcommand(ctx); err != nil {
+				return err
 			}
 			Run(ctx, options...)
 			return nil

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -102,10 +102,10 @@ func Commands(options ...micro.Option) []*cli.Command {
 			},
 		},
 		Action: func(ctx *cli.Context) error {
-			if ctx.Args().First() != "" {
+			if first := ctx.Args().First(); first != "" {
 				// received something that isn't a subcommand
 				cli.ShowSubcommandHelp(ctx)
-				return fmt.Errorf("Unrecognized subcommand %s", ctx.Args().First())
+				return fmt.Errorf("Unrecognized subcommand %s", first)
 			}
 			Run(ctx, options...)
 			return nil

--- a/service/store/store.go
+++ b/service/store/store.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"fmt"
+
 	"github.com/micro/cli/v2"
 	"github.com/micro/go-micro/v2"
 	log "github.com/micro/go-micro/v2/logger"
@@ -102,8 +104,8 @@ func Commands(options ...micro.Option) []*cli.Command {
 		Action: func(ctx *cli.Context) error {
 			if ctx.Args().First() != "" {
 				// received something that isn't a subcommand
-				return cli.ShowAppHelp(ctx)
-
+				cli.ShowSubcommandHelp(ctx)
+				return fmt.Errorf("Unrecognized subcommand %s", ctx.Args().First())
 			}
 			Run(ctx, options...)
 			return nil


### PR DESCRIPTION
Only done for services that have subcommands
- auth
- config
- network
- registry
- store

Addresses https://github.com/micro/development/issues/198