### PR TITLE
Fixing help for subcommands

### DIFF
--- a/client/cli/util/util.go
+++ b/client/cli/util/util.go
@@ -62,6 +62,12 @@ func isBuiltinService(command string) bool {
 
 // SetupCommand includes things that should run for each command.
 func SetupCommand(ctx *ccli.Context) {
+	// This makes `micro [command name] --help` work without a server
+	for _, arg := range os.Args {
+		if arg == "--help" || arg == "-h" {
+			return
+		}
+	}
 	switch ctx.Args().First() {
 	case "new", "server", "help":
 		return

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -74,7 +74,7 @@ func TLSConfig(ctx *cli.Context) (*tls.Config, error) {
 func UnexpectedSubcommand(ctx *cli.Context) error {
 	if first := ctx.Args().First(); first != "" {
 		// received something that isn't a subcommand
-		return fmt.Errorf("Unrecognized subcommand for %s: %s. Please refer to '%s help'", ctx.App.Name, first, ctx.App.Name)
+		return fmt.Errorf("Unrecognized subcommand for %s: %s. Please refer to '%s --help'", ctx.App.Name, first, ctx.App.Name)
 	}
 	return nil
 }
@@ -88,9 +88,9 @@ func UnexpectedCommand(ctx *cli.Context) error {
 			commandName = arg
 		}
 	}
-	return fmt.Errorf("Unrecognized micro command: %s. Please refer to 'micro help'", commandName)
+	return fmt.Errorf("Unrecognized micro command: %s. Please refer to 'micro --help'", commandName)
 }
 
 func MissingCommand(ctx *cli.Context) error {
-	return fmt.Errorf("No command provided to micro. Please refer to 'micro help'")
+	return fmt.Errorf("No command provided to micro. Please refer to 'micro --help'")
 }

--- a/test/misc_test.go
+++ b/test/misc_test.go
@@ -108,3 +108,36 @@ func testWrongCommands(t *t) {
 		t.Fatalf("Unexpected output for unrecognized subcommand: %v", string(outp))
 	}
 }
+
+// TestHelps ensures all `micro [command name] help` && `micro [command name] --help` commands are working.
+func TestHelps(t *testing.T) {
+	trySuite(t, testHelps, retryCount)
+}
+
+func testHelps(t *t) {
+	comm := exec.Command("micro", "help")
+	outp, err := comm.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+	commands := strings.Split(strings.Split(string(outp), "COMMANDS:")[1], "GLOBAL OPTIONS:")[0]
+	for _, line := range strings.Split(commands, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if len(trimmed) == 0 {
+			continue
+		}
+		// no help for help ;)
+		if strings.Contains(trimmed, "help") {
+			continue
+		}
+		commandName := strings.Split(trimmed, " ")[0]
+		comm = exec.Command("micro", commandName, "help")
+		outp, err = comm.CombinedOutput()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(outp), "micro "+commandName+" -") {
+			t.Fatal(commandName + " output is wrong: " + string(outp))
+		}
+	}
+}

--- a/test/misc_test.go
+++ b/test/misc_test.go
@@ -3,6 +3,7 @@
 package test
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -131,13 +132,16 @@ func testHelps(t *t) {
 			continue
 		}
 		commandName := strings.Split(trimmed, " ")[0]
-		comm = exec.Command("micro", commandName, "help")
+		comm = exec.Command("micro", commandName, "--help")
 		outp, err = comm.CombinedOutput()
+
 		if err != nil {
-			t.Fatal(err)
+			t.Fatal(fmt.Errorf("Command %v output is wrong: %v", commandName, string(outp)))
+			break
 		}
 		if !strings.Contains(string(outp), "micro "+commandName+" -") {
 			t.Fatal(commandName + " output is wrong: " + string(outp))
+			break
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/micro/development/issues/224

Changed suggestion to use `--help` as `micro new help` and similar etc might be a valid command.