### PR TITLE
Pass through args from micro server to core services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,3 +33,5 @@ require (
 	google.golang.org/genproto v0.0.0-20191216164720-4f79533eabd1
 	google.golang.org/grpc v1.26.0
 )
+
+replace github.com/micro/go-micro/v2 => ../go-micro

--- a/go.mod
+++ b/go.mod
@@ -33,5 +33,3 @@ require (
 	google.golang.org/genproto v0.0.0-20191216164720-4f79533eabd1
 	google.golang.org/grpc v1.26.0
 )
-
-replace github.com/micro/go-micro/v2 => ../go-micro

--- a/server/server.go
+++ b/server/server.go
@@ -99,7 +99,9 @@ func Run(context *cli.Context) error {
 	peer := context.Bool("peer")
 
 	// pass through the environment
-	env := []string{}
+	// By default we want a file store when we run micro server.
+	// This will get overridden if user has set their own MICRO_STORE env var or passed in --store
+	env := []string{"MICRO_STORE=file"}
 	env = append(env, "MICRO_RUNTIME_PROFILE="+context.String("profile"))
 	env = append(env, os.Environ()...)
 

--- a/server/server.go
+++ b/server/server.go
@@ -98,7 +98,11 @@ func Run(context *cli.Context) error {
 	// By default we want a file store when we run micro server.
 	// This will get overridden if user has set their own MICRO_STORE env var or passed in --store
 	env := []string{"MICRO_STORE=file"}
-	env = append(env, "MICRO_RUNTIME_PROFILE=server")
+	profile := context.String("profile")
+	if len(profile) == 0 {
+		profile = "server"
+	}
+	env = append(env, "MICRO_RUNTIME_PROFILE="+profile)
 	env = append(env, os.Environ()...)
 
 	// connect to the network if specified

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -31,7 +31,6 @@ COPY ./test/config-example-service ${GOPATH}/src/config-example-service
 # Speeding up tests by predownloading dependencies for services used.
 RUN cd ${GOPATH}/src/example-service && go get && \
     cd ${GOPATH}/src/config-example-service && go get && \
-    go get github.com/microhq/location-srv && \
     go get github.com/micro/services/helloworld
 
 # RUN go get github.com/crufter/micro-services/logspammer

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -31,7 +31,7 @@ COPY ./test/config-example-service ${GOPATH}/src/config-example-service
 # Speeding up tests by predownloading dependencies for services used.
 RUN cd ${GOPATH}/src/example-service && go get && \
     cd ${GOPATH}/src/config-example-service && go get && \
-    go get github.com/micro/services/location && \
+    go get github.com/microhq/location-srv && \
     go get github.com/micro/services/helloworld
 
 # RUN go get github.com/crufter/micro-services/logspammer

--- a/test/runtime_test.go
+++ b/test/runtime_test.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -68,7 +68,7 @@ func testRunLocalSource(t *t) {
 
 		// The started service should have the runtime name of "test/example-service",
 		// as the runtime name is the relative path inside a repo.
-		if !strings.Contains(string(outp), "test/example-service") {
+		if !statusRunning("test/example-service", outp) {
 			return outp, errors.New("Can't find example service in runtime")
 		}
 		return outp, err
@@ -112,7 +112,7 @@ func testRunAndKill(t *t) {
 
 		// The started service should have the runtime name of "test/example-service",
 		// as the runtime name is the relative path inside a repo.
-		if !strings.Contains(string(outp), "test/example-service") {
+		if !statusRunning("test/example-service", outp) {
 			return outp, errors.New("Can't find example service in runtime")
 		}
 		return outp, err
@@ -230,42 +230,10 @@ func testLocalOutsideRepo(t *t) {
 	}, 75*time.Second)
 }
 
-func TestLocalEnvRunGithubSource(t *testing.T) {
-	//trySuite(t, testLocalEnvRunGithubSource, retryCount)
-}
+func statusRunning(service string, statusOutput []byte) bool {
+	reg, _ := regexp.Compile(service + "\\s+latest\\s+\\S+\\s+running")
 
-func testLocalEnvRunGithubSource(t *t) {
-	t.Parallel()
-	outp, err := exec.Command("micro", "env", "set", "local").CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to set env to local, err: %v, output: %v", err, string(outp))
-		return
-	}
-	var cmd *exec.Cmd
-	go func() {
-		cmd = exec.Command("micro", "run", "location")
-		// fire and forget as this will run forever
-		cmd.CombinedOutput()
-	}()
-	time.Sleep(100 * time.Millisecond)
-	defer func() {
-		if cmd.Process != nil {
-			cmd.Process.Signal(syscall.SIGTERM)
-		}
-	}()
-
-	try("Find location", t, func() ([]byte, error) {
-		psCmd := exec.Command("micro", "status")
-		outp, err := psCmd.CombinedOutput()
-		if err != nil {
-			return outp, err
-		}
-
-		if !strings.Contains(string(outp), "location") {
-			return outp, errors.New("Output should contain location")
-		}
-		return outp, nil
-	}, 30*time.Second)
+	return reg.Match(statusOutput)
 }
 
 func TestRunGithubSource(t *testing.T) {
@@ -301,7 +269,7 @@ func testRunGithubSource(t *t) {
 			return outp, err
 		}
 
-		if !strings.Contains(string(outp), "helloworld") {
+		if !statusRunning("helloworld", outp) {
 			return outp, errors.New("Output should contain hello world")
 		}
 		return outp, nil
@@ -353,7 +321,7 @@ func testRunLocalUpdateAndCall(t *t) {
 
 		// The started service should have the runtime name of "test/example-service",
 		// as the runtime name is the relative path inside a repo.
-		if !strings.Contains(string(outp), "test/example-service") {
+		if !statusRunning("test/example-service", outp) {
 			return outp, errors.New("can't find service in runtime")
 		}
 		return outp, err


### PR DESCRIPTION
When running `micro server` env vars are passed to core services but global flags are not. 

e.g. `MICRO_STORE=cockroach micro server` works but `micro --store cockroach server` doesn't.

Closes https://github.com/micro/development/issues/225