### PR TITLE
Return quickly from unrecognised command

### DIFF
--- a/client/cli/util/util.go
+++ b/client/cli/util/util.go
@@ -79,6 +79,11 @@ func SetupCommand(ctx *ccli.Context) {
 		return
 	}
 
+	if ctx.App.Command(ctx.Args().First()) == nil {
+		// unrecognised command
+		return
+	}
+
 	toFlag := func(s string) string {
 		return strings.ToLower(strings.ReplaceAll(s, "MICRO_", ""))
 	}

--- a/test/misc_test.go
+++ b/test/misc_test.go
@@ -145,3 +145,12 @@ func testHelps(t *t) {
 		}
 	}
 }
+
+func TestUnrecognisedCommand(t *testing.T) {
+	t.Parallel()
+	outp, _ := exec.Command("micro", "foobar").CombinedOutput()
+	if !strings.Contains(string(outp), "Unrecognized micro command: foobar. Please refer to 'micro --help'") {
+		t.Fatalf("micro foobar does not return correct error %v", string(outp))
+		return
+	}
+}


### PR DESCRIPTION
If you don't have micro server running then unrecognised commands result in bad error trying to connect.

Before
```
$ micro foobar
{"id":"go.micro.client","code":500,"detail":"connection error: desc = \"transport: Error while dialing dial tcp 127.0.0.1:8081: connect: connection refused\"","status":"Internal Server Error"}
```


After
```
$ micro foobar 
Unrecognized micro command: foobar. Please refer to 'micro --help'
```