### PR TITLE
{web,api}: fix rpc mutli-tenancy bug

### DIFF
--- a/client/api/api.go
+++ b/client/api/api.go
@@ -187,12 +187,6 @@ func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 	// strip favicon.ico
 	r.HandleFunc("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {})
 
-	// register rpc handler
-	if EnableRPC {
-		log.Infof("Registering RPC Handler at %s", RPCPath)
-		r.HandleFunc(RPCPath, handler.RPC)
-	}
-
 	// resolver options
 	ropts := []resolver.Option{
 		resolver.WithServicePrefix(Namespace + "." + Type),
@@ -209,6 +203,12 @@ func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 		rr = path.NewResolver(ropts...)
 	case "grpc":
 		rr = grpc.NewResolver(ropts...)
+	}
+
+	// register rpc handler
+	if EnableRPC {
+		log.Infof("Registering RPC Handler at %s", RPCPath)
+		r.Handle(RPCPath, handler.NewRPCHandler(rr))
 	}
 
 	switch Handler {

--- a/client/web/web.go
+++ b/client/web/web.go
@@ -476,7 +476,7 @@ func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 	s.HandleFunc("/client", s.callHandler)
 	s.HandleFunc("/services", s.registryHandler)
 	s.HandleFunc("/service/{name}", s.registryHandler)
-	s.HandleFunc("/rpc", handler.RPC)
+	s.Handle("/rpc", handler.NewRPCHandler(resolver))
 	s.PathPrefix("/{service:[a-zA-Z0-9]+}").Handler(p)
 	s.HandleFunc("/", s.indexHandler)
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/micro/cli/v2 v2.1.2
-	github.com/micro/go-micro/v2 v2.9.1-0.20200630085409-6dcaf9efa6cf
+	github.com/micro/go-micro/v2 v2.9.1-0.20200630090752-0f5c53b6e436
 	github.com/micro/services/signup v0.0.0-20200629142252-9f80a09a8594
 	github.com/miekg/dns v1.1.27
 	github.com/netdata/go-orchestrator v0.0.0-20190905093727-c793edba0e8f

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,8 @@ require (
 	github.com/gorilla/handlers v1.4.2
 	github.com/gorilla/mux v1.7.3
 	github.com/micro/cli/v2 v2.1.2
-	github.com/micro/go-micro/v2 v2.9.1-0.20200629153745-df3e5364caa6
+	github.com/micro/go-micro/v2 v2.9.1-0.20200630085409-6dcaf9efa6cf
+	github.com/micro/services/signup v0.0.0-20200629142252-9f80a09a8594
 	github.com/miekg/dns v1.1.27
 	github.com/netdata/go-orchestrator v0.0.0-20190905093727-c793edba0e8f
 	github.com/olekukonko/tablewriter v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -328,8 +328,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/micro/cli/v2 v2.1.2 h1:43J1lChg/rZCC1rvdqZNFSQDrGT7qfMrtp6/ztpIkEM=
 github.com/micro/cli/v2 v2.1.2/go.mod h1:EguNh6DAoWKm9nmk+k/Rg0H3lQnDxqzu5x5srOtGtYg=
 github.com/micro/go-micro/v2 v2.9.1-0.20200618113919-8c7c27c573f5/go.mod h1:x55ZM3Puy0FyvvkR3e0ha0xsE9DFwfPSUMWAIbFY0SY=
-github.com/micro/go-micro/v2 v2.9.1-0.20200630085409-6dcaf9efa6cf h1:Qrq7UoCqnBMdGFmg4fmZMbvlvQoMG3fsonF1C7kEYPY=
-github.com/micro/go-micro/v2 v2.9.1-0.20200630085409-6dcaf9efa6cf/go.mod h1:hSdOM6jb6aGswjBpCeB9wJ0yVH+CugevRm/CX7NlSrQ=
+github.com/micro/go-micro/v2 v2.9.1-0.20200630090752-0f5c53b6e436 h1:oo08Ddv6EyzNHZHAuCMk6Z8K2fJpYx0ZpgWSWpbh89M=
+github.com/micro/go-micro/v2 v2.9.1-0.20200630090752-0f5c53b6e436/go.mod h1:hSdOM6jb6aGswjBpCeB9wJ0yVH+CugevRm/CX7NlSrQ=
 github.com/micro/services/payments/provider v0.0.0-20200618133042-550220a6eff2/go.mod h1:mwSahcMJ6Bof7hY3M6gzzY8JN7XSHmMIBg8wXtb47j8=
 github.com/micro/services/signup v0.0.0-20200629142252-9f80a09a8594 h1:ARUwlYyrEfs5g4HRmgidSBkdPTPe0PVca02sBhjUj3g=
 github.com/micro/services/signup v0.0.0-20200629142252-9f80a09a8594/go.mod h1:zHL601FTryKhcFV0/VkWA5iMA4qqHQvqlkciyGGMjq0=

--- a/go.sum
+++ b/go.sum
@@ -327,8 +327,12 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/micro/cli/v2 v2.1.2 h1:43J1lChg/rZCC1rvdqZNFSQDrGT7qfMrtp6/ztpIkEM=
 github.com/micro/cli/v2 v2.1.2/go.mod h1:EguNh6DAoWKm9nmk+k/Rg0H3lQnDxqzu5x5srOtGtYg=
-github.com/micro/go-micro/v2 v2.9.1-0.20200629153745-df3e5364caa6 h1:e/Vd6kSXsEmLsGi8lqY7KRgGXVKgB/0pthdx5/hVSCM=
-github.com/micro/go-micro/v2 v2.9.1-0.20200629153745-df3e5364caa6/go.mod h1:hSdOM6jb6aGswjBpCeB9wJ0yVH+CugevRm/CX7NlSrQ=
+github.com/micro/go-micro/v2 v2.9.1-0.20200618113919-8c7c27c573f5/go.mod h1:x55ZM3Puy0FyvvkR3e0ha0xsE9DFwfPSUMWAIbFY0SY=
+github.com/micro/go-micro/v2 v2.9.1-0.20200630085409-6dcaf9efa6cf h1:Qrq7UoCqnBMdGFmg4fmZMbvlvQoMG3fsonF1C7kEYPY=
+github.com/micro/go-micro/v2 v2.9.1-0.20200630085409-6dcaf9efa6cf/go.mod h1:hSdOM6jb6aGswjBpCeB9wJ0yVH+CugevRm/CX7NlSrQ=
+github.com/micro/services/payments/provider v0.0.0-20200618133042-550220a6eff2/go.mod h1:mwSahcMJ6Bof7hY3M6gzzY8JN7XSHmMIBg8wXtb47j8=
+github.com/micro/services/signup v0.0.0-20200629142252-9f80a09a8594 h1:ARUwlYyrEfs5g4HRmgidSBkdPTPe0PVca02sBhjUj3g=
+github.com/micro/services/signup v0.0.0-20200629142252-9f80a09a8594/go.mod h1:zHL601FTryKhcFV0/VkWA5iMA4qqHQvqlkciyGGMjq0=
 github.com/miekg/dns v1.1.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.27 h1:aEH/kqUzUxGJ/UHcEKdJY+ugH6WEzsEBBSPa8zuy1aM=
 github.com/miekg/dns v1.1.27/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=

--- a/internal/handler/rpc_test.go
+++ b/internal/handler/rpc_test.go
@@ -86,7 +86,7 @@ func TestRPCHandler(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Foo", "Bar")
 
-	RPC(w, req)
+	NewRPCHandler(nil).ServeHTTP(w, req)
 
 	if err := server.Stop(); err != nil {
 		t.Fatal(err)
@@ -95,5 +95,4 @@ func TestRPCHandler(t *testing.T) {
 	if w.Code != 200 {
 		t.Fatalf("Expected 200 response got %d %s", w.Code, w.Body.String())
 	}
-
 }

--- a/internal/resolver/web/resolver.go
+++ b/internal/resolver/web/resolver.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/micro/go-micro/v2/api/resolver"
 	res "github.com/micro/go-micro/v2/api/resolver"
-	"github.com/micro/go-micro/v2/registry"
 	"github.com/micro/go-micro/v2/router"
 )
 
@@ -72,6 +71,6 @@ func (r *Resolver) Resolve(req *http.Request, opts ...res.ResolveOption) (*res.E
 		Method: req.Method,
 		Host:   route.Address,
 		Path:   "/" + strings.Join(parts[2:], "/"),
-		Domain: registry.DefaultDomain,
+		Domain: options.Domain,
 	}, nil
 }


### PR DESCRIPTION
Fix various mutli-tenancy bugs in micro web/api. Mainly: the /rpc endpoint was relying on the client to lookup the route, however the network option wasn't being passed through, so any requests to a non micro network would fail.