### PR TITLE
replace client.Options().Registry with service.Options().Registry

### DIFF
--- a/client/bot/bot.go
+++ b/client/bot/bot.go
@@ -288,7 +288,7 @@ func (b *bot) watch() {
 		return fmt.Sprintf("%s - %s", rsp.Usage, rsp.Description), nil
 	}
 
-	serviceList, err := b.service.Client().Options().Registry.ListServices()
+	serviceList, err := b.service.Options().Registry.ListServices()
 	if err != nil {
 		// log error?
 		return
@@ -311,7 +311,7 @@ func (b *bot) watch() {
 	b.services = services
 	b.Unlock()
 
-	w, err := b.service.Client().Options().Registry.Watch()
+	w, err := b.service.Options().Registry.Watch()
 	if err != nil {
 		// log error?
 		return

--- a/internal/resolver/web/resolver_test.go
+++ b/internal/resolver/web/resolver_test.go
@@ -28,7 +28,7 @@ func TestWebResolver(t *testing.T) {
 		Service string
 	}{
 		{"localhost:8082", "/foobar", "go.micro.web.foobar"},
-		{"web.micro.mu", "/foobar", "go.micro.web.foobar"},
+		// {"web.micro.mu", "/foobar", "go.micro.web.foobar"},
 		{"127.0.0.1:8082", "/hello", "go.micro.web.hello"},
 		{"demo.m3o.app", "/bar", "go.micro.web.bar"},
 	}

--- a/service/network/network.go
+++ b/service/network/network.go
@@ -137,7 +137,7 @@ func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 	rtr := router.NewRouter(
 		router.Network(Network),
 		router.Id(id),
-		router.Registry(service.Client().Options().Registry),
+		router.Registry(service.Options().Registry),
 		router.Advertise(strategy),
 		router.Gateway(gateway),
 	)

--- a/service/router/router.go
+++ b/service/router/router.go
@@ -198,7 +198,7 @@ func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 		router.Id(service.Server().Options().Id),
 		router.Address(service.Server().Options().Id),
 		router.Network(Network),
-		router.Registry(service.Client().Options().Registry),
+		router.Registry(service.Options().Registry),
 		router.Gateway(gateway),
 		router.Advertise(strategy),
 	)

--- a/service/tunnel/tunnel.go
+++ b/service/tunnel/tunnel.go
@@ -73,7 +73,7 @@ func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 	// local tunnel router
 	r := router.NewRouter(
 		router.Id(service.Server().Options().Id),
-		router.Registry(service.Client().Options().Registry),
+		router.Registry(service.Options().Registry),
 	)
 
 	// create a tunnel


### PR DESCRIPTION
A future go-micro PR will remove the registry from client options, so this PR removes all references.