### PR TITLE
client/api: bugfix for namespace with versioning

### DIFF
--- a/client/api/api.go
+++ b/client/api/api.go
@@ -195,7 +195,7 @@ func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 
 	// resolver options
 	ropts := []resolver.Option{
-		resolver.WithServicePrefix(Namespace + "." + Type),
+		resolver.WithServicePrefix(apiNamespace),
 		resolver.WithHandler(Handler),
 	}
 

--- a/client/api/api.go
+++ b/client/api/api.go
@@ -85,8 +85,14 @@ func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 		Namespace = strings.TrimSuffix(ctx.String("namespace"), "."+Type)
 	}
 
-	// apiNamespace has the format: "go.micro.api"
-	apiNamespace := Namespace + "." + Type
+	// if the namespace was foo.api.v1, it would excape the trim suffix check
+	// above and we want to use this as our API namespace
+	var apiNamespace string
+	if strings.Contains(Namespace, ".api.") {
+		apiNamespace = Namespace
+	} else {
+		apiNamespace = Namespace + "." + Type
+	}
 
 	// append name to opts
 	srvOpts = append(srvOpts, micro.Name(Name))


### PR DESCRIPTION
Fixes `micro --namespace=foo.api.v1 api` not resolving `/bar` to `foo.api.v1.bar`.