### PR TITLE
Make `micro services` the canonical command to list services

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ micro env set server
 micro run example
 
 # list services
-micro list services
+micro services
 
 # call a service
 micro call go.micro.service.example Example.Call '{"name": "John"}'

--- a/client/cli/cli.go
+++ b/client/cli/cli.go
@@ -15,6 +15,7 @@ var (
 	prompt = "micro> "
 
 	commands = map[string]*command{
+		"services":   {"services", "List services in the registry", listServices},
 		"quit":   {"quit", "Exit the CLI", quit},
 		"exit":   {"exit", "Exit the CLI", quit},
 		"call":   {"call", "Call a service", callService},
@@ -279,6 +280,11 @@ func RegistryCommands() []*cli.Command {
 					Action: Print(getService),
 				},
 			},
+		},
+		{
+			Name:  "services",
+			Usage: "List services in the registry",
+			Action: Print(listServices),
 		},
 	}
 }


### PR DESCRIPTION
There is a certain magic to `micro services` and it should be the thing you type when you want to list services running in any environment. Quite simply a list of services in the registry.