### PR TITLE
micro env del

### DIFF
--- a/client/cli/cli.go
+++ b/client/cli/cli.go
@@ -530,15 +530,23 @@ func Commands() []*cli.Command {
 			Subcommands: []*cli.Command{
 				{
 					Name:   "get",
+					Usage:  "Get the currently selected environment",
 					Action: Print(getEnv),
 				},
 				{
 					Name:   "set",
+					Usage:  "Set the environment to use for subsequent commands",
 					Action: Print(setEnv),
 				},
 				{
 					Name:   "add",
+					Usage:  "Add a new environment `micro env add foo 127.0.0.1:8081`",
 					Action: Print(addEnv),
+				},
+				{
+					Name:   "del",
+					Usage:  "Delete an environment from your list",
+					Action: Print(delEnv),
 				},
 			},
 		},

--- a/client/cli/helpers.go
+++ b/client/cli/helpers.go
@@ -158,6 +158,14 @@ func addEnv(c *cli.Context, args []string) ([]byte, error) {
 	return nil, nil
 }
 
+func delEnv(c *cli.Context, args []string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, errors.New("name required")
+	}
+	cliutil.DelEnv(args[0])
+	return nil, nil
+}
+
 // netCall calls services through the network
 func netCall(c *cli.Context, args []string) ([]byte, error) {
 	os.Setenv("MICRO_PROXY", "go.micro.network")

--- a/client/cli/util/util.go
+++ b/client/cli/util/util.go
@@ -231,6 +231,18 @@ func SetEnv(envName string) {
 	config.Set(envName, "env")
 }
 
+// DelEnv deletes an env from config
+func DelEnv(envName string) {
+	envs := getEnvs()
+	_, ok := envs[envName]
+	if !ok {
+		fmt.Printf("Environment '%v' does not exist\n", envName)
+		os.Exit(1)
+	}
+	delete(envs, envName)
+	setEnvs(envs)
+}
+
 func IsLocal(ctx *ccli.Context) bool {
 	return GetEnv(ctx).Name == EnvLocal
 }

--- a/test/env_test.go
+++ b/test/env_test.go
@@ -52,3 +52,65 @@ func testEnvOverrides(t *t) {
 		return
 	}
 }
+
+func TestEnvOps(t *testing.T) {
+	trySuite(t, testEnvOps, retryCount)
+}
+
+func testEnvOps(t *t) {
+	// add an env
+	_, err := exec.Command("micro", "env", "add", "fooTestEnvOps", "127.0.0.1:8081").CombinedOutput()
+	if err != nil {
+		t.Fatalf("Error running micro env %s", err)
+		return
+	}
+	outp, err := exec.Command("micro", "env").CombinedOutput()
+	if err != nil {
+		t.Fatalf("Error running micro env %s", err)
+		return
+	}
+	if !strings.Contains(string(outp), "fooTestEnvOps") {
+		t.Fatalf("Cannot find expected environment. Output %s", outp)
+		return
+	}
+
+	// can we actually set it correctly
+	_, err = exec.Command("micro", "env", "set", "fooTestEnvOps").CombinedOutput()
+	if err != nil {
+		t.Fatalf("Error running micro env %s", err)
+		return
+	}
+	outp, err = exec.Command("micro", "env").CombinedOutput()
+	if err != nil {
+		t.Fatalf("Error running micro env %s", err)
+		return
+	}
+	if !strings.Contains(string(outp), "* fooTestEnvOps") {
+		t.Fatalf("Environment not set. Output %s", outp)
+		return
+	}
+
+	_, err = exec.Command("micro", "env", "set", "local").CombinedOutput()
+	if err != nil {
+		t.Fatalf("Error running micro env %s", err)
+		return
+	}
+
+	// we should be able to delete it too
+	_, err = exec.Command("micro", "env", "del", "fooTestEnvOps").CombinedOutput()
+	if err != nil {
+		t.Fatalf("Error running micro env %s", err)
+		return
+	}
+
+	outp, err = exec.Command("micro", "env").CombinedOutput()
+	if err != nil {
+		t.Fatalf("Error running micro env %s", err)
+		return
+	}
+	if strings.Contains(string(outp), "fooTestEnvOps") {
+		t.Fatalf("Found unexpected environment. Output %s", outp)
+		return
+	}
+
+}

--- a/test/test_framework.go
+++ b/test/test_framework.go
@@ -216,16 +216,19 @@ type t struct {
 }
 
 func (t *t) Fatal(values ...interface{}) {
+	t.t.Helper()
 	t.t.Log(values...)
 	t.failed = true
 	t.values = values
 }
 
 func (t *t) Log(values ...interface{}) {
+	t.t.Helper()
 	t.t.Log(values...)
 }
 
 func (t *t) Fatalf(format string, values ...interface{}) {
+	t.t.Helper()
 	t.t.Log(fmt.Sprintf(format, values...))
 	t.failed = true
 	t.values = values
@@ -245,6 +248,7 @@ func newT(te *testing.T) *t {
 
 // trySuite is designed to retry a TestXX function
 func trySuite(t *testing.T, f func(t *t), times int) {
+	t.Helper()
 	tee := newT(t)
 	for i := 0; i < times; i++ {
 		f(tee)


### PR DESCRIPTION
Also fix test logging to report line of error rather than test_framework.go

```
=== RUN   TestEnvOps
    TestEnvOps: env_test.go:108: Error running micro env exit status 1
    TestEnvOps: env_test.go:108: Error running micro env exit status 1
    TestEnvOps: env_test.go:57: Error running micro env exit status 1
--- FAIL: TestEnvOps (0.89s)
FAIL
FAIL	github.com/micro/micro/v2/test	1.189s
FAIL

```