### PR TITLE
Set current namespace back to DefaultDomain instead of erroring when …

### DIFF
--- a/client/cli/namespace/namespace.go
+++ b/client/cli/namespace/namespace.go
@@ -75,7 +75,10 @@ func Remove(namespace, env string) error {
 		return err
 	}
 	if current == namespace {
-		return errors.New("Cannot remove the current namespace")
+		err = Set(registry.DefaultDomain, env)
+		if err != nil {
+			return err
+		}
 	}
 
 	existing, err := List(env)

--- a/client/cli/namespace/namespace_test.go
+++ b/client/cli/namespace/namespace_test.go
@@ -109,7 +109,7 @@ func TestNamespace(t *testing.T) {
 
 	t.Run("RemoveSetNamespace", func(t *testing.T) {
 		err := Remove(namespace, envName)
-		assert.Error(t, err, "Removing a namespace which is currently set should error")
+		assert.Nil(t, err, "Removing a namespace which is currently set should not error")
 	})
 
 	t.Run("SetDefaultNamespace", func(t *testing.T) {

--- a/client/cli/namespace/namespace_test.go
+++ b/client/cli/namespace/namespace_test.go
@@ -117,6 +117,17 @@ func TestNamespace(t *testing.T) {
 		assert.Nil(t, err, "Setting the default namespace should not error")
 	})
 
+	// Adding and setting valid namesapce again to test removal
+	t.Run("AddValidNamespace", func(t *testing.T) {
+		err := Add(namespace, envName)
+		assert.Nil(t, err, "Adding a valid namespace to an environment should not return an error")
+	})
+
+	t.Run("SetValidNamespace", func(t *testing.T) {
+		err := Set(namespace, envName)
+		assert.Nil(t, err, "Setting a valid namespace should not error")
+	})
+
 	t.Run("RemoveValidNamespace", func(t *testing.T) {
 		err := Remove(namespace, envName)
 		assert.Nil(t, err, "Removing a valid namespace from an environment should not return an error")


### PR DESCRIPTION
I think if namespaces default to DefaultDomain then erroring when deleting a current domain should just fall back to default.

This came up during the teardown of a test I'm working on.