### PR TITLE
Tests: explicitly return after try, defer before launch

### DIFF
--- a/test/auth_test.go
+++ b/test/auth_test.go
@@ -19,8 +19,10 @@ func TestServerAuth(t *testing.T) {
 func testServerAuth(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	basicAuthSuite(serv, t)
 }
@@ -34,8 +36,10 @@ func testServerAuthJWT(t *t) {
 	serv := newServer(t, options{
 		auth: "jwt",
 	})
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	basicAuthSuite(serv, t)
 }
@@ -45,7 +49,7 @@ func basicAuthSuite(serv server, t *t) {
 
 	// Execute first command in read to wait for store service
 	// to start up
-	try("Calling micro auth list accounts", t, func() ([]byte, error) {
+	if err := try("Calling micro auth list accounts", t, func() ([]byte, error) {
 		readCmd := exec.Command("micro", serv.envFlag(), "auth", "list", "accounts")
 		outp, err := readCmd.CombinedOutput()
 		if err != nil {
@@ -56,9 +60,11 @@ func basicAuthSuite(serv server, t *t) {
 			return outp, fmt.Errorf("Output should contain default admin account")
 		}
 		return outp, nil
-	}, 15*time.Second)
+	}, 15*time.Second); err != nil {
+		return
+	}
 
-	try("Calling micro auth list rules", t, func() ([]byte, error) {
+	if err := try("Calling micro auth list rules", t, func() ([]byte, error) {
 		readCmd := exec.Command("micro", serv.envFlag(), "auth", "list", "rules")
 		outp, err := readCmd.CombinedOutput()
 		if err != nil {
@@ -68,9 +74,11 @@ func basicAuthSuite(serv server, t *t) {
 			return outp, fmt.Errorf("Output should contain default rule")
 		}
 		return outp, nil
-	}, 8*time.Second)
+	}, 8*time.Second); err != nil {
+		return
+	}
 
-	try("Try to get token with default account", t, func() ([]byte, error) {
+	if err := try("Try to get token with default account", t, func() ([]byte, error) {
 		readCmd := exec.Command("micro", serv.envFlag(), "call", "go.micro.auth", "Auth.Token", `{"id":"default","secret":"password"}`)
 		outp, err := readCmd.CombinedOutput()
 		if err != nil {
@@ -95,5 +103,7 @@ func basicAuthSuite(serv server, t *t) {
 			return outp, fmt.Errorf("Can't find access token")
 		}
 		return outp, nil
-	}, 8*time.Second)
+	}, 8*time.Second); err != nil {
+		return
+	}
 }

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -20,10 +20,12 @@ func TestConfig(t *testing.T) {
 func testConfig(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
-	try("Calling micro config read", t, func() ([]byte, error) {
+	if err := try("Calling micro config read", t, func() ([]byte, error) {
 		getCmd := exec.Command("micro", serv.envFlag(), "config", "get", "somekey")
 		outp, err := getCmd.CombinedOutput()
 		if err == nil {
@@ -33,12 +35,14 @@ func testConfig(t *t) {
 			return outp, fmt.Errorf("Output should be 'not found\n', got %v", string(outp))
 		}
 		return outp, nil
-	}, 5*time.Second)
+	}, 5*time.Second); err != nil {
+		return
+	}
 
 	// This needs to be retried to the the "error listing rules"
 	// error log output that happens when the auth service is not yet available.
 
-	try("Calling micro config set", t, func() ([]byte, error) {
+	if err := try("Calling micro config set", t, func() ([]byte, error) {
 		setCmd := exec.Command("micro", serv.envFlag(), "config", "set", "somekey", "val1")
 		outp, err := setCmd.CombinedOutput()
 		if err != nil {
@@ -50,7 +54,7 @@ func testConfig(t *t) {
 		return outp, err
 	}, 5*time.Second)
 
-	try("micro config get somekey", t, func() ([]byte, error) {
+	if err := try("micro config get somekey", t, func() ([]byte, error) {
 		getCmd := exec.Command("micro", serv.envFlag(), "config", "get", "somekey")
 		outp, err := getCmd.CombinedOutput()
 		if err != nil {
@@ -60,7 +64,9 @@ func testConfig(t *t) {
 			return outp, errors.New("Expected 'val1\n'")
 		}
 		return outp, err
-	}, 8*time.Second)
+	}, 8*time.Second); err != nil {
+		return
+	}
 
 	delCmd := exec.Command("micro", serv.envFlag(), "config", "del", "somekey")
 	outp, err := delCmd.CombinedOutput()
@@ -73,7 +79,7 @@ func testConfig(t *t) {
 		return
 	}
 
-	try("micro config get somekey", t, func() ([]byte, error) {
+	if err := try("micro config get somekey", t, func() ([]byte, error) {
 		getCmd := exec.Command("micro", serv.envFlag(), "config", "get", "somekey")
 		outp, err = getCmd.CombinedOutput()
 		if err == nil {
@@ -83,7 +89,9 @@ func testConfig(t *t) {
 			return outp, errors.New("Expected 'not found\n'")
 		}
 		return outp, nil
-	}, 8*time.Second)
+	}, 8*time.Second); err != nil {
+		return
+	}
 
 	// Testing dot notation
 	setCmd := exec.Command("micro", serv.envFlag(), "config", "set", "someotherkey.subkey", "otherval1")
@@ -97,7 +105,7 @@ func testConfig(t *t) {
 		return
 	}
 
-	try("micro config get someotherkey.subkey", t, func() ([]byte, error) {
+	if err := try("micro config get someotherkey.subkey", t, func() ([]byte, error) {
 		getCmd := exec.Command("micro", serv.envFlag(), "config", "get", "someotherkey.subkey")
 		outp, err = getCmd.CombinedOutput()
 		if err != nil {
@@ -107,7 +115,9 @@ func testConfig(t *t) {
 			return outp, errors.New("Expected 'otherval1\n'")
 		}
 		return outp, err
-	}, 8*time.Second)
+	}, 8*time.Second); err != nil {
+		return
+	}
 }
 
 func TestConfigReadFromService(t *testing.T) {
@@ -117,8 +127,10 @@ func TestConfigReadFromService(t *testing.T) {
 func testConfigReadFromService(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	dirname := "config-read-example"
 	folderPath := filepath.Join(os.TempDir(), dirname)
@@ -145,7 +157,7 @@ func testConfigReadFromService(t *t) {
 
 	// This needs to be retried to the the "error listing rules"
 	// error log output that happens when the auth service is not yet available.
-	try("Calling micro config set", t, func() ([]byte, error) {
+	if err := try("Calling micro config set", t, func() ([]byte, error) {
 		setCmd := exec.Command("micro", serv.envFlag(), "config", "set", "key.subkey", "val1")
 		outp, err := setCmd.CombinedOutput()
 		if err != nil {
@@ -155,9 +167,11 @@ func testConfigReadFromService(t *t) {
 			return outp, fmt.Errorf("Expected no output, got: %v", string(outp))
 		}
 		return outp, err
-	}, 5*time.Second)
+	}, 5*time.Second); err != nil {
+		return
+	}
 
-	try("Try logs read", t, func() ([]byte, error) {
+	if err := try("Try logs read", t, func() ([]byte, error) {
 		setCmd := exec.Command("micro", serv.envFlag(), "logs", "-n", "1", dirname)
 		outp, err := setCmd.CombinedOutput()
 		if err != nil {
@@ -168,5 +182,7 @@ func testConfigReadFromService(t *t) {
 			return outp, fmt.Errorf("Expected val1 in output, got: %v", string(outp))
 		}
 		return outp, err
-	}, 20*time.Second)
+	}, 20*time.Second); err != nil {
+		return
+	}
 }

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -52,7 +52,9 @@ func testConfig(t *t) {
 			return outp, fmt.Errorf("Expected no output, got: %v", string(outp))
 		}
 		return outp, err
-	}, 5*time.Second)
+	}, 5*time.Second); err != nil {
+		return
+	}
 
 	if err := try("micro config get somekey", t, func() ([]byte, error) {
 		getCmd := exec.Command("micro", serv.envFlag(), "config", "get", "somekey")

--- a/test/m3o_test.go
+++ b/test/m3o_test.go
@@ -136,6 +136,9 @@ func testM3oSignupFlow(t *t) {
 			t.Fatalf("Eror getting namespace: %v", err)
 			return
 		}
+		defer func() {
+			namespace.Remove(ns, serv.envName)
+		}()
 		if strings.Count(ns, "_") != 2 {
 			t.Fatalf("Expected 2 underscores in namespace but namespace is: %v", ns)
 			return

--- a/test/misc_test.go
+++ b/test/misc_test.go
@@ -99,8 +99,10 @@ func testWrongCommands(t *t) {
 	// is running. This is most likely because some config/auth wrapper in the background failing.
 	// Fix this later.
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	t.Parallel()
 

--- a/test/runtime_test.go
+++ b/test/runtime_test.go
@@ -30,16 +30,20 @@ func testServerModeCall(t *t) {
 		return
 	}
 
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
-	try("Calling Runtime.Read", t, func() ([]byte, error) {
+	if err := try("Calling Runtime.Read", t, func() ([]byte, error) {
 		outp, err = exec.Command("micro", serv.envFlag(), "call", "go.micro.runtime", "Runtime.Read", "{}").CombinedOutput()
 		if err != nil {
 			return outp, errors.New("Call to runtime read should succeed")
 		}
 		return outp, err
-	}, 5*time.Second)
+	}, 5*time.Second); err != nil {
+		return
+	}
 }
 
 func TestRunLocalSource(t *testing.T) {
@@ -49,8 +53,10 @@ func TestRunLocalSource(t *testing.T) {
 func testRunLocalSource(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	runCmd := exec.Command("micro", serv.envFlag(), "run", "./example-service")
 	outp, err := runCmd.CombinedOutput()
@@ -59,7 +65,7 @@ func testRunLocalSource(t *t) {
 		return
 	}
 
-	try("Find test/example", t, func() ([]byte, error) {
+	if err := try("Find test/example", t, func() ([]byte, error) {
 		psCmd := exec.Command("micro", serv.envFlag(), "status")
 		outp, err = psCmd.CombinedOutput()
 		if err != nil {
@@ -72,9 +78,11 @@ func testRunLocalSource(t *t) {
 			return outp, errors.New("Can't find example service in runtime")
 		}
 		return outp, err
-	}, 15*time.Second)
+	}, 15*time.Second); err != nil {
+		return
+	}
 
-	try("Find go.micro.service.example in list", t, func() ([]byte, error) {
+	if err := try("Find go.micro.service.example in list", t, func() ([]byte, error) {
 		outp, err := exec.Command("micro", serv.envFlag(), "list", "services").CombinedOutput()
 		if err != nil {
 			return outp, err
@@ -83,7 +91,9 @@ func testRunLocalSource(t *t) {
 			return outp, errors.New("Can't find example service in list")
 		}
 		return outp, err
-	}, 50*time.Second)
+	}, 50*time.Second); err != nil {
+		return
+	}
 }
 
 func TestRunAndKill(t *testing.T) {
@@ -93,8 +103,10 @@ func TestRunAndKill(t *testing.T) {
 func testRunAndKill(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	runCmd := exec.Command("micro", serv.envFlag(), "run", "./example-service")
 	outp, err := runCmd.CombinedOutput()
@@ -103,7 +115,7 @@ func testRunAndKill(t *t) {
 		return
 	}
 
-	try("Find test/example", t, func() ([]byte, error) {
+	if err := try("Find test/example", t, func() ([]byte, error) {
 		psCmd := exec.Command("micro", serv.envFlag(), "status")
 		outp, err = psCmd.CombinedOutput()
 		if err != nil {
@@ -116,9 +128,11 @@ func testRunAndKill(t *t) {
 			return outp, errors.New("Can't find example service in runtime")
 		}
 		return outp, err
-	}, 15*time.Second)
+	}, 15*time.Second); err != nil {
+		return
+	}
 
-	try("Find go.micro.service.example in list", t, func() ([]byte, error) {
+	if err := try("Find go.micro.service.example in list", t, func() ([]byte, error) {
 		outp, err := exec.Command("micro", serv.envFlag(), "list", "services").CombinedOutput()
 		if err != nil {
 			return outp, err
@@ -127,7 +141,9 @@ func testRunAndKill(t *t) {
 			return outp, errors.New("Can't find example service in list")
 		}
 		return outp, err
-	}, 50*time.Second)
+	}, 50*time.Second); err != nil {
+		return
+	}
 
 	outp, err = exec.Command("micro", serv.envFlag(), "kill", "test/example-service").CombinedOutput()
 	if err != nil {
@@ -135,7 +151,7 @@ func testRunAndKill(t *t) {
 		return
 	}
 
-	try("Find test/example", t, func() ([]byte, error) {
+	if err := try("Find test/example", t, func() ([]byte, error) {
 		psCmd := exec.Command("micro", serv.envFlag(), "status")
 		outp, err = psCmd.CombinedOutput()
 		if err != nil {
@@ -148,9 +164,11 @@ func testRunAndKill(t *t) {
 			return outp, errors.New("Should not find example service in runtime")
 		}
 		return outp, err
-	}, 15*time.Second)
+	}, 15*time.Second); err != nil {
+		return
+	}
 
-	try("Find go.micro.service.example in list", t, func() ([]byte, error) {
+	if err := try("Find go.micro.service.example in list", t, func() ([]byte, error) {
 		outp, err := exec.Command("micro", serv.envFlag(), "list", "services").CombinedOutput()
 		if err != nil {
 			return outp, err
@@ -159,7 +177,9 @@ func testRunAndKill(t *t) {
 			return outp, errors.New("Should not find example service in list")
 		}
 		return outp, err
-	}, 20*time.Second)
+	}, 20*time.Second); err != nil {
+		return
+	}
 }
 
 func TestLocalOutsideRepo(t *testing.T) {
@@ -169,8 +189,10 @@ func TestLocalOutsideRepo(t *testing.T) {
 func testLocalOutsideRepo(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	dirname := "last-dir-of-path"
 	folderPath := filepath.Join(os.TempDir(), dirname)
@@ -198,7 +220,7 @@ func testLocalOutsideRepo(t *t) {
 		return
 	}
 
-	try("Find "+dirname, t, func() ([]byte, error) {
+	if err := try("Find "+dirname, t, func() ([]byte, error) {
 		psCmd := exec.Command("micro", serv.envFlag(), "status")
 		outp, err = psCmd.CombinedOutput()
 		if err != nil {
@@ -216,9 +238,11 @@ func testLocalOutsideRepo(t *t) {
 			return outp, errors.New("Can't find '" + dirname + "' in runtime")
 		}
 		return outp, err
-	}, 12*time.Second)
+	}, 12*time.Second); err != nil {
+		return
+	}
 
-	try("Find go.micro.service.example in list", t, func() ([]byte, error) {
+	if err := try("Find go.micro.service.example in list", t, func() ([]byte, error) {
 		outp, err := exec.Command("micro", serv.envFlag(), "list", "services").CombinedOutput()
 		if err != nil {
 			return outp, err
@@ -227,7 +251,9 @@ func testLocalOutsideRepo(t *t) {
 			return outp, errors.New("Can't find example service in list")
 		}
 		return outp, err
-	}, 75*time.Second)
+	}, 75*time.Second); err != nil {
+		return
+	}
 }
 
 func statusRunning(service string, statusOutput []byte) bool {
@@ -252,8 +278,10 @@ func testRunGithubSource(t *t) {
 		return
 	}
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	runCmd := exec.Command("micro", serv.envFlag(), "run", "github.com/micro/examples/helloworld")
 	outp, err := runCmd.CombinedOutput()
@@ -262,7 +290,7 @@ func testRunGithubSource(t *t) {
 		return
 	}
 
-	try("Find hello world", t, func() ([]byte, error) {
+	if err := try("Find hello world", t, func() ([]byte, error) {
 		psCmd := exec.Command("micro", serv.envFlag(), "status")
 		outp, err = psCmd.CombinedOutput()
 		if err != nil {
@@ -273,9 +301,11 @@ func testRunGithubSource(t *t) {
 			return outp, errors.New("Output should contain hello world")
 		}
 		return outp, nil
-	}, 60*time.Second)
+	}, 60*time.Second); err != nil {
+		return
+	}
 
-	try("Call hello world", t, func() ([]byte, error) {
+	if err := try("Call hello world", t, func() ([]byte, error) {
 		callCmd := exec.Command("micro", serv.envFlag(), "call", "go.micro.service.helloworld", "Helloworld.Call", `{"name": "Joe"}`)
 		outp, err := callCmd.CombinedOutput()
 		if err != nil {
@@ -290,7 +320,9 @@ func testRunGithubSource(t *t) {
 			return outp, errors.New("Helloworld resonse is unexpected")
 		}
 		return outp, err
-	}, 60*time.Second)
+	}, 60*time.Second); err != nil {
+		return
+	}
 
 }
 
@@ -301,8 +333,10 @@ func TestRunLocalUpdateAndCall(t *testing.T) {
 func testRunLocalUpdateAndCall(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	// Run the example service
 	runCmd := exec.Command("micro", serv.envFlag(), "run", "./example-service")
@@ -312,7 +346,7 @@ func testRunLocalUpdateAndCall(t *t) {
 		return
 	}
 
-	try("Finding example service with micro status", t, func() ([]byte, error) {
+	if err := try("Finding example service with micro status", t, func() ([]byte, error) {
 		psCmd := exec.Command("micro", serv.envFlag(), "status")
 		outp, err = psCmd.CombinedOutput()
 		if err != nil {
@@ -325,9 +359,11 @@ func testRunLocalUpdateAndCall(t *t) {
 			return outp, errors.New("can't find service in runtime")
 		}
 		return outp, err
-	}, 15*time.Second)
+	}, 15*time.Second); err != nil {
+		return
+	}
 
-	try("Call example service", t, func() ([]byte, error) {
+	if err := try("Call example service", t, func() ([]byte, error) {
 		callCmd := exec.Command("micro", serv.envFlag(), "call", "go.micro.service.example", "Example.Call", `{"name": "Joe"}`)
 		outp, err := callCmd.CombinedOutput()
 		if err != nil {
@@ -342,7 +378,9 @@ func testRunLocalUpdateAndCall(t *t) {
 			return outp, errors.New("Response is unexpected")
 		}
 		return outp, err
-	}, 50*time.Second)
+	}, 50*time.Second); err != nil {
+		return
+	}
 
 	replaceStringInFile(t, "./example-service/handler/handler.go", "Hello", "Hi")
 	defer func() {
@@ -357,7 +395,7 @@ func testRunLocalUpdateAndCall(t *t) {
 		return
 	}
 
-	try("Call example service after modification", t, func() ([]byte, error) {
+	if err := try("Call example service after modification", t, func() ([]byte, error) {
 		callCmd := exec.Command("micro", serv.envFlag(), "call", "go.micro.service.example", "Example.Call", `{"name": "Joe"}`)
 		outp, err = callCmd.CombinedOutput()
 		if err != nil {
@@ -372,7 +410,9 @@ func testRunLocalUpdateAndCall(t *t) {
 			return outp, errors.New("Response is not what's expected")
 		}
 		return outp, err
-	}, 15*time.Second)
+	}, 15*time.Second); err != nil {
+		return
+	}
 }
 
 func TestExistingLogs(t *testing.T) {
@@ -382,8 +422,10 @@ func TestExistingLogs(t *testing.T) {
 func testExistingLogs(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	runCmd := exec.Command("micro", serv.envFlag(), "run", "github.com/crufter/micro-services/logspammer")
 	outp, err := runCmd.CombinedOutput()
@@ -392,7 +434,7 @@ func testExistingLogs(t *t) {
 		return
 	}
 
-	try("logspammer logs", t, func() ([]byte, error) {
+	if err := try("logspammer logs", t, func() ([]byte, error) {
 		psCmd := exec.Command("micro", serv.envFlag(), "logs", "-n", "5", "crufter/micro-services/logspammer")
 		outp, err = psCmd.CombinedOutput()
 		if err != nil {
@@ -403,7 +445,9 @@ func testExistingLogs(t *t) {
 			return outp, errors.New("Output does not contain expected")
 		}
 		return outp, nil
-	}, 50*time.Second)
+	}, 50*time.Second); err != nil {
+		return
+	}
 }
 
 func TestBranchCheckout(t *testing.T) {
@@ -413,8 +457,10 @@ func TestBranchCheckout(t *testing.T) {
 func testBranchCheckout(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	runCmd := exec.Command("micro", serv.envFlag(), "run", "github.com/crufter/micro-services/logspammer@branch-checkout-test")
 	outp, err := runCmd.CombinedOutput()
@@ -423,7 +469,7 @@ func testBranchCheckout(t *t) {
 		return
 	}
 
-	try("logspammer logs", t, func() ([]byte, error) {
+	if err := try("logspammer logs", t, func() ([]byte, error) {
 		psCmd := exec.Command("micro", serv.envFlag(), "logs", "-n", "5", "crufter/micro-services/logspammer")
 		outp, err = psCmd.CombinedOutput()
 		if err != nil {
@@ -435,7 +481,9 @@ func testBranchCheckout(t *t) {
 			return outp, errors.New("Output does not contain expected")
 		}
 		return outp, nil
-	}, 50*time.Second)
+	}, 50*time.Second); err != nil {
+		return
+	}
 }
 
 func TestStreamLogsAndThirdPartyRepo(t *testing.T) {
@@ -445,8 +493,10 @@ func TestStreamLogsAndThirdPartyRepo(t *testing.T) {
 func testStreamLogsAndThirdPartyRepo(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	runCmd := exec.Command("micro", serv.envFlag(), "run", "github.com/crufter/micro-services/logspammer")
 	outp, err := runCmd.CombinedOutput()
@@ -455,7 +505,7 @@ func testStreamLogsAndThirdPartyRepo(t *t) {
 		return
 	}
 
-	try("logspammer logs", t, func() ([]byte, error) {
+	if err := try("logspammer logs", t, func() ([]byte, error) {
 		psCmd := exec.Command("micro", serv.envFlag(), "logs", "-n", "5", "crufter/micro-services/logspammer")
 		outp, err = psCmd.CombinedOutput()
 		if err != nil {
@@ -466,7 +516,9 @@ func testStreamLogsAndThirdPartyRepo(t *t) {
 			return outp, errors.New("Output does not contain expected")
 		}
 		return outp, nil
-	}, 50*time.Second)
+	}, 50*time.Second); err != nil {
+		return
+	}
 
 	// Test streaming logs
 	cmd := exec.Command("micro", serv.envFlag(), "logs", "-n", "1", "-f", "crufter-micro-services-logspammer")
@@ -530,8 +582,10 @@ func TestParentDependency(t *testing.T) {
 func testParentDependency(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	runCmd := exec.Command("micro", serv.envFlag(), "run", "./dep-test/dep-test-service")
 	outp, err := runCmd.CombinedOutput()
@@ -540,7 +594,7 @@ func testParentDependency(t *t) {
 		return
 	}
 
-	try("Find hello world", t, func() ([]byte, error) {
+	if err := try("Find hello world", t, func() ([]byte, error) {
 		psCmd := exec.Command("micro", serv.envFlag(), "status")
 		outp, err = psCmd.CombinedOutput()
 		if err != nil {
@@ -551,7 +605,9 @@ func testParentDependency(t *t) {
 			return outp, errors.New("Output should contain hello world")
 		}
 		return outp, nil
-	}, 30*time.Second)
+	}, 30*time.Second); err != nil {
+		return
+	}
 }
 
 func TestFastRuns(t *testing.T) {
@@ -561,8 +617,10 @@ func TestFastRuns(t *testing.T) {
 func testFastRuns(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	runCmd := exec.Command("micro", serv.envFlag(), "run", "signup")
 	outp, err := runCmd.CombinedOutput()
@@ -588,7 +646,7 @@ func testFastRuns(t *t) {
 		return
 	}
 
-	try("Find signup and stripe", t, func() ([]byte, error) {
+	if err := try("Find signup and stripe", t, func() ([]byte, error) {
 		psCmd := exec.Command("micro", serv.envFlag(), "list", "services")
 		outp, err = psCmd.CombinedOutput()
 		if err != nil {
@@ -599,5 +657,7 @@ func testFastRuns(t *t) {
 			return outp, errors.New("Signup or stripe can't be found")
 		}
 		return outp, nil
-	}, 120*time.Second)
+	}, 120*time.Second); err != nil {
+		return
+	}
 }

--- a/test/store_test.go
+++ b/test/store_test.go
@@ -18,12 +18,14 @@ func TestStore(t *testing.T) {
 func testStore(t *t) {
 	t.Parallel()
 	serv := newServer(t)
-	serv.launch()
 	defer serv.close()
+	if err := serv.launch(); err != nil {
+		return
+	}
 
 	// Execute first command in read to wait for store service
 	// to start up
-	try("Calling micro store read", t, func() ([]byte, error) {
+	if err := try("Calling micro store read", t, func() ([]byte, error) {
 		readCmd := exec.Command("micro", serv.envFlag(), "store", "read", "somekey")
 		outp, err := readCmd.CombinedOutput()
 		if err == nil {
@@ -33,7 +35,9 @@ func testStore(t *t) {
 			return outp, fmt.Errorf("Output should be 'not found\n', got %v", string(outp))
 		}
 		return outp, nil
-	}, 8*time.Second)
+	}, 8*time.Second); err != nil {
+		return
+	}
 
 	writeCmd := exec.Command("micro", serv.envFlag(), "store", "write", "somekey", "val1")
 	outp, err := writeCmd.CombinedOutput()

--- a/test/test_framework.go
+++ b/test/test_framework.go
@@ -11,6 +11,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/micro/micro/v2/client/cli/token"
 )
 
 const (
@@ -209,6 +211,7 @@ func (s server) launch() error {
 }
 
 func (s server) close() {
+	token.Remove(s.envName)
 	exec.Command("docker", "kill", s.containerName).CombinedOutput()
 	if s.cmd.Process != nil {
 		s.cmd.Process.Signal(syscall.SIGKILL)


### PR DESCRIPTION
There have been cases where the error output of tests was very confusing: `Calling micro server` and such errors appearing at the end of the test after later error messages. This was because the tests were not being terminated after an unsuccessful `try`.