### PR TITLE
client/proxy: remove incorrect auth options

### DIFF
--- a/client/proxy/proxy.go
+++ b/client/proxy/proxy.go
@@ -174,18 +174,7 @@ func Run(ctx *cli.Context, srvOpts ...micro.Option) {
 		serverOpts = append(serverOpts, server.TLSConfig(config))
 	}
 
-	// add auth wrapper to server
-	var authOpts []auth.Option
-	if ctx.IsSet("auth_public_key") {
-		authOpts = append(authOpts, auth.PublicKey(ctx.String("auth_public_key")))
-	}
-	if ctx.IsSet("auth_private_key") {
-		authOpts = append(authOpts, auth.PublicKey(ctx.String("auth_private_key")))
-	}
-
-	a := *cmd.DefaultOptions().Auth
-	a.Init(authOpts...)
-	authFn := func() auth.Auth { return a }
+	authFn := func() auth.Auth { return *cmd.DefaultOptions().Auth }
 	authOpt := server.WrapHandler(wrapper.AuthHandler(authFn))
 	serverOpts = append(serverOpts, authOpt)
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/micro/cli/v2 v2.1.2
-	github.com/micro/go-micro/v2 v2.9.1-0.20200713142714-a4252ba69c86
+	github.com/micro/go-micro/v2 v2.9.1-0.20200713160619-c7c1c066c16e
 	github.com/micro/services v0.0.0-20200710134101-ae48cf29b8ba
 	github.com/miekg/dns v1.1.27
 	github.com/netdata/go-orchestrator v0.0.0-20190905093727-c793edba0e8f

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/micro/cli/v2 v2.1.2 h1:43J1lChg/rZCC1rvdqZNFSQDrGT7qfMrtp6/ztpIkEM=
 github.com/micro/cli/v2 v2.1.2/go.mod h1:EguNh6DAoWKm9nmk+k/Rg0H3lQnDxqzu5x5srOtGtYg=
 github.com/micro/go-micro/v2 v2.9.1-0.20200709192134-3480e0a64e21/go.mod h1:Szpx+Q9oZvNOoGc1cPweBt3PozVX4e/z3SC1hpxV4iw=
-github.com/micro/go-micro/v2 v2.9.1-0.20200713142714-a4252ba69c86 h1:hf5DIeknwoTSI2DnuCLg4GThM2y13LrWipWdH0eJ4sA=
-github.com/micro/go-micro/v2 v2.9.1-0.20200713142714-a4252ba69c86/go.mod h1:Szpx+Q9oZvNOoGc1cPweBt3PozVX4e/z3SC1hpxV4iw=
+github.com/micro/go-micro/v2 v2.9.1-0.20200713160619-c7c1c066c16e h1:uRwsyly0a71d4f2BAYY3EQRLzBidjL1xy9LmETANzEU=
+github.com/micro/go-micro/v2 v2.9.1-0.20200713160619-c7c1c066c16e/go.mod h1:Szpx+Q9oZvNOoGc1cPweBt3PozVX4e/z3SC1hpxV4iw=
 github.com/micro/services v0.0.0-20200710134101-ae48cf29b8ba h1:EJYESGctpl9cm4pkUMjL9CVcabKBiJA9biiTYpgUnSM=
 github.com/micro/services v0.0.0-20200710134101-ae48cf29b8ba/go.mod h1:myTgDHdIZUM5EzrYLBgBSmxalNvhpK6wxBkIL4zkENA=
 github.com/miekg/dns v1.1.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=


### PR DESCRIPTION
Options are already set in config/cmd.go