### PR TITLE
service/runtime/profile: set router for platform services

### DIFF
--- a/service/runtime/profile/profile.go
+++ b/service/runtime/profile/profile.go
@@ -63,6 +63,7 @@ func Platform() []string {
 		"MICRO_NETWORK=service",
 		"MICRO_REGISTRY=service",
 		"MICRO_RUNTIME=service",
+		"MICRO_ROUTER=service",
 		"MICRO_STORE=service",
 		// now set the addresses
 		"MICRO_AUTH_ADDRESS=micro-auth.default.svc:8010",


### PR DESCRIPTION
Fixes this error when a service starts on the platform:
```
2020-07-15 08:14:05  file=router/default.go:528 level=warn Error watching the registry: rpc error: code = PermissionDenied desc = {"id":"go.micro.registry","code":403,"detail":"Access denied to namespace","status":"Forbidden"}
```