### PR TITLE
Make Go cells support commit and branch refs

### DIFF
--- a/service/runtime/service.go
+++ b/service/runtime/service.go
@@ -166,6 +166,9 @@ func runService(ctx *cli.Context, srvOpts ...micro.Option) {
 	} else {
 		// when using the micro/cells:go image, we pass the source as the argument
 		args = runtimeSource
+		if len(source.Ref) > 0 {
+			args += "@" + source.Ref
+		}
 	}
 
 	// specify the options


### PR DESCRIPTION
Test the cell with:

```
docker build -t xx . && docker run xx github.com/crufter/micro-services/logspammer@d2d52c4897135c0e4d02b66e23b3a3ecdbafbcde

docker build -t xx . && docker run xx github.com/crufter/micro-services/logspammer@latest

docker build -t xx . && docker run xx github.com/crufter/micro-services/logspammer@branch-checkout-test

docker build -t xx . && docker run xx github.com/crufter/micro-services/logspammer
# etc
```

Args are mostly only used with k8s runtime so this has no effect on the local one (as tests show).
Update does not modify args which is fine because changing ref (args) would mean an other version being created, ie. currently different branches etc are being treated as different services.