### PR TITLE
Scope binary execution to micro-

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -365,7 +365,8 @@ func Setup(app *ccli.App, options ...micro.Option) {
 	// boot micro runtime
 	app.Action = func(c *ccli.Context) error {
 		if c.Args().Len() > 0 {
-			command := c.Args().First()
+			// prefix with micro
+			command := "micro-" + c.Args().First()
 
 			v, err := exec.LookPath(command)
 			if err != nil {


### PR DESCRIPTION
When we fall through with no built in command we try to execute binaries. We need to scope this to `micro-` prefixed binaries.