### PR TITLE
Resurrect micro whoami as micro user

### DIFF
--- a/service/auth/cli/user.go
+++ b/service/auth/cli/user.go
@@ -1,0 +1,50 @@
+// Package user providers the micro user cli command
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/micro/cli/v2"
+	"github.com/micro/micro/v2/client/cli/util"
+	"github.com/micro/micro/v2/cmd"
+	"github.com/micro/micro/v2/internal/config"
+)
+
+// user returns info about the logged in user
+func user(ctx *cli.Context) error {
+	env := util.GetEnv(ctx)
+
+	// Get the token from micro config
+	tok, err := config.Get("micro", "auth", env.Name, "token")
+	if err != nil {
+		fmt.Println("You are not logged in")
+		os.Exit(1)
+	}
+
+	// Inspect the token
+	a, err := authFromContext(ctx)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	acc, err := a.Inspect(tok)
+	if err != nil {
+		fmt.Println("failure", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(acc.ID)
+	return nil
+}
+
+func init() {
+	cmd.Register(
+		&cli.Command{
+			Name:   "user",
+			Usage:  "Print the current logged in user",
+			Action: user,
+		},
+	)
+}


### PR DESCRIPTION
`micro user` becomes the canonical source for all user settings

```
# display logged in user
micro user

TODO:
# display user config
micro user config
# set config
micro user config set [name]
```