### PR TITLE
cmd/protoc-gen-micro: update to use v3 defaults

### DIFF
--- a/cmd/protoc-gen-micro/plugin/micro/micro.go
+++ b/cmd/protoc-gen-micro/plugin/micro/micro.go
@@ -86,6 +86,7 @@ func (g *micro) Generate(file *generator.FileDescriptor) {
 	g.P("var _ ", apiPkg, ".Endpoint")
 	g.P("var _ ", contextPkg, ".Context")
 	g.P("var _ ", clientPkg, ".Option")
+	g.P("var _ ", serverPkg, ".Option")
 	g.P("var _ = ", microServerPkg, ".Handle")
 	g.P("var _ = ", microClientPkg, ".Call")
 	g.P()

--- a/cmd/protoc-gen-micro/plugin/micro/micro.go
+++ b/cmd/protoc-gen-micro/plugin/micro/micro.go
@@ -15,10 +15,12 @@ import (
 // Paths for packages used by code generated in this file,
 // relative to the import_prefix of the generator.Generator.
 const (
-	apiPkgPath     = "github.com/micro/go-micro/v3/api"
-	contextPkgPath = "context"
-	clientPkgPath  = "github.com/micro/go-micro/v3/client"
-	serverPkgPath  = "github.com/micro/go-micro/v3/server"
+	apiPkgPath         = "github.com/micro/go-micro/v3/api"
+	contextPkgPath     = "context"
+	clientPkgPath      = "github.com/micro/go-micro/v3/client"
+	serverPkgPath      = "github.com/micro/go-micro/v3/server"
+	microServerPkgPath = "github.com/micro/micro/v3/service/server"
+	microClientPkgPath = "github.com/micro/micro/v3/service/client"
 )
 
 func init() {
@@ -40,11 +42,13 @@ func (g *micro) Name() string {
 // They may vary from the final path component of the import path
 // if the name is used by other packages.
 var (
-	apiPkg     string
-	contextPkg string
-	clientPkg  string
-	serverPkg  string
-	pkgImports map[generator.GoPackageName]bool
+	apiPkg         string
+	contextPkg     string
+	clientPkg      string
+	serverPkg      string
+	microClientPkg string
+	microServerPkg string
+	pkgImports     map[generator.GoPackageName]bool
 )
 
 // Init initializes the plugin.
@@ -54,6 +58,8 @@ func (g *micro) Init(gen *generator.Generator) {
 	contextPkg = generator.RegisterUniquePackageName("context", nil)
 	clientPkg = generator.RegisterUniquePackageName("client", nil)
 	serverPkg = generator.RegisterUniquePackageName("server", nil)
+	microClientPkg = generator.RegisterUniquePackageName("microClient", nil)
+	microServerPkg = generator.RegisterUniquePackageName("microServer", nil)
 }
 
 // Given a type name defined in a .proto, return its object.
@@ -80,7 +86,8 @@ func (g *micro) Generate(file *generator.FileDescriptor) {
 	g.P("var _ ", apiPkg, ".Endpoint")
 	g.P("var _ ", contextPkg, ".Context")
 	g.P("var _ ", clientPkg, ".Option")
-	g.P("var _ ", serverPkg, ".Option")
+	g.P("var _ = ", microServerPkg, ".Handle")
+	g.P("var _ = ", microClientPkg, ".Call")
 	g.P()
 
 	for i, service := range file.FileDescriptorProto.Service {
@@ -98,6 +105,8 @@ func (g *micro) GenerateImports(file *generator.FileDescriptor, imports map[gene
 	g.P(contextPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, contextPkgPath)))
 	g.P(clientPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, clientPkgPath)))
 	g.P(serverPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, serverPkgPath)))
+	g.P(microServerPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, microServerPkgPath)))
+	g.P(microClientPkg, " ", strconv.Quote(path.Join(g.gen.ImportPrefix, microClientPkgPath)))
 	g.P(")")
 	g.P()
 
@@ -174,13 +183,12 @@ func (g *micro) generateService(file *generator.FileDescriptor, service *pb.Serv
 
 	// Client structure.
 	g.P("type ", unexport(servAlias), " struct {")
-	g.P("c ", clientPkg, ".Client")
 	g.P("name string")
 	g.P("}")
 	g.P()
 
 	// NewClient factory.
-	g.P("func New", servAlias, " (name string, c ", clientPkg, ".Client) ", servAlias, " {")
+	g.P("func New", servAlias, " (name string) ", servAlias, " {")
 	/*
 		g.P("if c == nil {")
 		g.P("c = ", clientPkg, ".NewClient()")
@@ -189,10 +197,7 @@ func (g *micro) generateService(file *generator.FileDescriptor, service *pb.Serv
 		g.P(`name = "`, serviceName, `"`)
 		g.P("}")
 	*/
-	g.P("return &", unexport(servAlias), "{")
-	g.P("c: c,")
-	g.P("name: name,")
-	g.P("}")
+	g.P("return &", unexport(servAlias), "{name: name}")
 	g.P("}")
 	g.P()
 	var methodIndex, streamIndex int
@@ -226,7 +231,7 @@ func (g *micro) generateService(file *generator.FileDescriptor, service *pb.Serv
 	g.P()
 
 	// Server registration.
-	g.P("func Register", servName, "Handler(s ", serverPkg, ".Server, hdlr ", serverType, ", opts ...", serverPkg, ".HandlerOption) error {")
+	g.P("func Register", servName, "Handler(hdlr ", serverType, ", opts ...", serverPkg, ".HandlerOption) error {")
 	g.P("type ", unexport(servName), " interface {")
 
 	// generate interface methods
@@ -253,7 +258,7 @@ func (g *micro) generateService(file *generator.FileDescriptor, service *pb.Serv
 			g.P("}))")
 		}
 	}
-	g.P("return s.Handle(s.NewHandler(&", servName, "{h}, opts...))")
+	g.P("return ", microServerPkg, ".Handle(", microServerPkg, ".NewHandler(&", servName, "{h}, opts...))")
 	g.P("}")
 	g.P()
 
@@ -349,10 +354,10 @@ func (g *micro) generateClientMethod(reqServ, servName, serviceDescVar string, m
 
 	g.P("func (c *", unexport(servAlias), ") ", g.generateClientSignature(servName, method), "{")
 	if !method.GetServerStreaming() && !method.GetClientStreaming() {
-		g.P(`req := c.c.NewRequest(c.name, "`, reqMethod, `", in)`)
+		g.P(`req := `, microClientPkg, `.NewRequest(c.name, "`, reqMethod, `", in)`)
 		g.P("out := new(", outType, ")")
 		// TODO: Pass descExpr to Invoke.
-		g.P("err := ", `c.c.Call(ctx, req, out, opts...)`)
+		g.P("err := ", microClientPkg, `.Call(ctx, req, out, opts...)`)
 		g.P("if err != nil { return nil, err }")
 		g.P("return out, nil")
 		g.P("}")
@@ -360,8 +365,8 @@ func (g *micro) generateClientMethod(reqServ, servName, serviceDescVar string, m
 		return
 	}
 	streamType := unexport(servAlias) + methName
-	g.P(`req := c.c.NewRequest(c.name, "`, reqMethod, `", &`, inType, `{})`)
-	g.P("stream, err := c.c.Stream(ctx, req, opts...)")
+	g.P(`req := `, microClientPkg, `.NewRequest(c.name, "`, reqMethod, `", &`, inType, `{})`)
+	g.P("stream, err := ", microClientPkg, ".Stream(ctx, req, opts...)")
 	g.P("if err != nil { return nil, err }")
 
 	if !method.GetClientStreaming() {

--- a/service/server/server.go
+++ b/service/server/server.go
@@ -10,3 +10,23 @@ import (
 var DefaultServer server.Server = grpc.NewServer(
 	server.Registry(registry.DefaultRegistry),
 )
+
+// Register a handler
+func Handle(hdlr server.Handler) error {
+	return DefaultServer.Handle(hdlr)
+}
+
+// Create a new handler
+func NewHandler(hdlr interface{}, opts ...server.HandlerOption) server.Handler {
+	return DefaultServer.NewHandler(hdlr, opts...)
+}
+
+// Create a new subscriber
+func NewSubscriber(topic string, hdlr interface{}, opts ...server.SubscriberOption) server.Subscriber {
+	return DefaultServer.NewSubscriber(topic, hdlr, opts...)
+}
+
+// Register a subscriber
+func Subscribe(sub server.Subscriber) error {
+	return DefaultServer.Subscribe(sub)
+}


### PR DESCRIPTION
You no longer need to pass srv.Server() when registering a handler:

```go
	// New Service
	helloworld := service.New(service.Name("helloworld"))

	// Register Handler
	pb.RegisterHelloworldHandler(new(handler.Helloworld))

	// Run service
	if err := helloworld.Run(); err != nil {
		logger.Fatal(err)
	}
```

or pass srv.Client() when creating a client:
```go
cli := pb.NewHelloworldService("helloworld")
```