### PR TITLE
cmd/protoc-gen-micro: add public accessors

### DIFF
--- a/client/bot/proto/bot.pb.micro.go
+++ b/client/bot/proto/bot.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -57,6 +58,8 @@ func NewCommandService(name string) CommandService {
 	return &commandService{name: name}
 }
 
+var defaultCommandService = NewCommandService("command")
+
 func (c *commandService) Help(ctx context.Context, in *HelpRequest, opts ...client.CallOption) (*HelpResponse, error) {
 	req := microClient.NewRequest(c.name, "Command.Help", in)
 	out := new(HelpResponse)
@@ -67,6 +70,10 @@ func (c *commandService) Help(ctx context.Context, in *HelpRequest, opts ...clie
 	return out, nil
 }
 
+func CommandHelp(ctx context.Context, in *HelpRequest, opts ...client.CallOption) (*HelpResponse, error) {
+	return defaultCommandService.Help(ctx, in, opts...)
+}
+
 func (c *commandService) Exec(ctx context.Context, in *ExecRequest, opts ...client.CallOption) (*ExecResponse, error) {
 	req := microClient.NewRequest(c.name, "Command.Exec", in)
 	out := new(ExecResponse)
@@ -75,6 +82,10 @@ func (c *commandService) Exec(ctx context.Context, in *ExecRequest, opts ...clie
 		return nil, err
 	}
 	return out, nil
+}
+
+func CommandExec(ctx context.Context, in *ExecRequest, opts ...client.CallOption) (*ExecResponse, error) {
+	return defaultCommandService.Exec(ctx, in, opts...)
 }
 
 // Server API for Command service

--- a/cmd/protoc-gen-micro/examples/greeter/greeter.pb.micro.go
+++ b/cmd/protoc-gen-micro/examples/greeter/greeter.pb.micro.go
@@ -34,6 +34,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -73,6 +74,8 @@ func NewGreeterService(name string) GreeterService {
 	return &greeterService{name: name}
 }
 
+var defaultGreeterService = NewGreeterService("greeter")
+
 func (c *greeterService) Hello(ctx context.Context, in *Request, opts ...client.CallOption) (*Response, error) {
 	req := microClient.NewRequest(c.name, "Greeter.Hello", in)
 	out := new(Response)
@@ -81,6 +84,10 @@ func (c *greeterService) Hello(ctx context.Context, in *Request, opts ...client.
 		return nil, err
 	}
 	return out, nil
+}
+
+func GreeterHello(ctx context.Context, in *Request, opts ...client.CallOption) (*Response, error) {
+	return defaultGreeterService.Hello(ctx, in, opts...)
 }
 
 func (c *greeterService) Stream(ctx context.Context, opts ...client.CallOption) (Greeter_StreamService, error) {
@@ -132,6 +139,10 @@ func (x *greeterServiceStream) Recv() (*Response, error) {
 		return nil, err
 	}
 	return m, nil
+}
+
+func GreeterStream(ctx context.Context, opts ...client.CallOption) (Greeter_StreamService, error) {
+	return defaultGreeterService.Stream(ctx, opts...)
 }
 
 // Server API for Greeter service

--- a/platform/proto/alert/alert.pb.micro.go
+++ b/platform/proto/alert/alert.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -57,6 +58,8 @@ func NewAlertService(name string) AlertService {
 	return &alertService{name: name}
 }
 
+var defaultAlertService = NewAlertService("alert")
+
 func (c *alertService) ReportEvent(ctx context.Context, in *ReportEventRequest, opts ...client.CallOption) (*ReportEventResponse, error) {
 	req := microClient.NewRequest(c.name, "Alert.ReportEvent", in)
 	out := new(ReportEventResponse)
@@ -65,6 +68,10 @@ func (c *alertService) ReportEvent(ctx context.Context, in *ReportEventRequest, 
 		return nil, err
 	}
 	return out, nil
+}
+
+func AlertReportEvent(ctx context.Context, in *ReportEventRequest, opts ...client.CallOption) (*ReportEventResponse, error) {
+	return defaultAlertService.ReportEvent(ctx, in, opts...)
 }
 
 // Server API for Alert service

--- a/platform/proto/signup/signup.pb.micro.go
+++ b/platform/proto/signup/signup.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -61,6 +62,8 @@ func NewSignupService(name string) SignupService {
 	return &signupService{name: name}
 }
 
+var defaultSignupService = NewSignupService("signup")
+
 func (c *signupService) SendVerificationEmail(ctx context.Context, in *SendVerificationEmailRequest, opts ...client.CallOption) (*SendVerificationEmailResponse, error) {
 	req := microClient.NewRequest(c.name, "Signup.SendVerificationEmail", in)
 	out := new(SendVerificationEmailResponse)
@@ -69,6 +72,10 @@ func (c *signupService) SendVerificationEmail(ctx context.Context, in *SendVerif
 		return nil, err
 	}
 	return out, nil
+}
+
+func SignupSendVerificationEmail(ctx context.Context, in *SendVerificationEmailRequest, opts ...client.CallOption) (*SendVerificationEmailResponse, error) {
+	return defaultSignupService.SendVerificationEmail(ctx, in, opts...)
 }
 
 func (c *signupService) Verify(ctx context.Context, in *VerifyRequest, opts ...client.CallOption) (*VerifyResponse, error) {
@@ -81,6 +88,10 @@ func (c *signupService) Verify(ctx context.Context, in *VerifyRequest, opts ...c
 	return out, nil
 }
 
+func SignupVerify(ctx context.Context, in *VerifyRequest, opts ...client.CallOption) (*VerifyResponse, error) {
+	return defaultSignupService.Verify(ctx, in, opts...)
+}
+
 func (c *signupService) CompleteSignup(ctx context.Context, in *CompleteSignupRequest, opts ...client.CallOption) (*CompleteSignupResponse, error) {
 	req := microClient.NewRequest(c.name, "Signup.CompleteSignup", in)
 	out := new(CompleteSignupResponse)
@@ -89,6 +100,10 @@ func (c *signupService) CompleteSignup(ctx context.Context, in *CompleteSignupRe
 		return nil, err
 	}
 	return out, nil
+}
+
+func SignupCompleteSignup(ctx context.Context, in *CompleteSignupRequest, opts ...client.CallOption) (*CompleteSignupResponse, error) {
+	return defaultSignupService.CompleteSignup(ctx, in, opts...)
 }
 
 // Server API for Signup service

--- a/service/auth/proto/auth.pb.micro.go
+++ b/service/auth/proto/auth.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -58,6 +59,8 @@ func NewAuthService(name string) AuthService {
 	return &authService{name: name}
 }
 
+var defaultAuthService = NewAuthService("auth")
+
 func (c *authService) Generate(ctx context.Context, in *GenerateRequest, opts ...client.CallOption) (*GenerateResponse, error) {
 	req := microClient.NewRequest(c.name, "Auth.Generate", in)
 	out := new(GenerateResponse)
@@ -66,6 +69,10 @@ func (c *authService) Generate(ctx context.Context, in *GenerateRequest, opts ..
 		return nil, err
 	}
 	return out, nil
+}
+
+func AuthGenerate(ctx context.Context, in *GenerateRequest, opts ...client.CallOption) (*GenerateResponse, error) {
+	return defaultAuthService.Generate(ctx, in, opts...)
 }
 
 func (c *authService) Inspect(ctx context.Context, in *InspectRequest, opts ...client.CallOption) (*InspectResponse, error) {
@@ -78,6 +85,10 @@ func (c *authService) Inspect(ctx context.Context, in *InspectRequest, opts ...c
 	return out, nil
 }
 
+func AuthInspect(ctx context.Context, in *InspectRequest, opts ...client.CallOption) (*InspectResponse, error) {
+	return defaultAuthService.Inspect(ctx, in, opts...)
+}
+
 func (c *authService) Token(ctx context.Context, in *TokenRequest, opts ...client.CallOption) (*TokenResponse, error) {
 	req := microClient.NewRequest(c.name, "Auth.Token", in)
 	out := new(TokenResponse)
@@ -86,6 +97,10 @@ func (c *authService) Token(ctx context.Context, in *TokenRequest, opts ...clien
 		return nil, err
 	}
 	return out, nil
+}
+
+func AuthToken(ctx context.Context, in *TokenRequest, opts ...client.CallOption) (*TokenResponse, error) {
+	return defaultAuthService.Token(ctx, in, opts...)
 }
 
 // Server API for Auth service
@@ -146,6 +161,8 @@ func NewAccountsService(name string) AccountsService {
 	return &accountsService{name: name}
 }
 
+var defaultAccountsService = NewAccountsService("accounts")
+
 func (c *accountsService) List(ctx context.Context, in *ListAccountsRequest, opts ...client.CallOption) (*ListAccountsResponse, error) {
 	req := microClient.NewRequest(c.name, "Accounts.List", in)
 	out := new(ListAccountsResponse)
@@ -156,6 +173,10 @@ func (c *accountsService) List(ctx context.Context, in *ListAccountsRequest, opt
 	return out, nil
 }
 
+func AccountsList(ctx context.Context, in *ListAccountsRequest, opts ...client.CallOption) (*ListAccountsResponse, error) {
+	return defaultAccountsService.List(ctx, in, opts...)
+}
+
 func (c *accountsService) Delete(ctx context.Context, in *DeleteAccountRequest, opts ...client.CallOption) (*DeleteAccountResponse, error) {
 	req := microClient.NewRequest(c.name, "Accounts.Delete", in)
 	out := new(DeleteAccountResponse)
@@ -164,6 +185,10 @@ func (c *accountsService) Delete(ctx context.Context, in *DeleteAccountRequest, 
 		return nil, err
 	}
 	return out, nil
+}
+
+func AccountsDelete(ctx context.Context, in *DeleteAccountRequest, opts ...client.CallOption) (*DeleteAccountResponse, error) {
+	return defaultAccountsService.Delete(ctx, in, opts...)
 }
 
 // Server API for Accounts service
@@ -219,6 +244,8 @@ func NewRulesService(name string) RulesService {
 	return &rulesService{name: name}
 }
 
+var defaultRulesService = NewRulesService("rules")
+
 func (c *rulesService) Create(ctx context.Context, in *CreateRequest, opts ...client.CallOption) (*CreateResponse, error) {
 	req := microClient.NewRequest(c.name, "Rules.Create", in)
 	out := new(CreateResponse)
@@ -227,6 +254,10 @@ func (c *rulesService) Create(ctx context.Context, in *CreateRequest, opts ...cl
 		return nil, err
 	}
 	return out, nil
+}
+
+func RulesCreate(ctx context.Context, in *CreateRequest, opts ...client.CallOption) (*CreateResponse, error) {
+	return defaultRulesService.Create(ctx, in, opts...)
 }
 
 func (c *rulesService) Delete(ctx context.Context, in *DeleteRequest, opts ...client.CallOption) (*DeleteResponse, error) {
@@ -239,6 +270,10 @@ func (c *rulesService) Delete(ctx context.Context, in *DeleteRequest, opts ...cl
 	return out, nil
 }
 
+func RulesDelete(ctx context.Context, in *DeleteRequest, opts ...client.CallOption) (*DeleteResponse, error) {
+	return defaultRulesService.Delete(ctx, in, opts...)
+}
+
 func (c *rulesService) List(ctx context.Context, in *ListRequest, opts ...client.CallOption) (*ListResponse, error) {
 	req := microClient.NewRequest(c.name, "Rules.List", in)
 	out := new(ListResponse)
@@ -247,6 +282,10 @@ func (c *rulesService) List(ctx context.Context, in *ListRequest, opts ...client
 		return nil, err
 	}
 	return out, nil
+}
+
+func RulesList(ctx context.Context, in *ListRequest, opts ...client.CallOption) (*ListResponse, error) {
+	return defaultRulesService.List(ctx, in, opts...)
 }
 
 // Server API for Rules service

--- a/service/broker/proto/broker.pb.micro.go
+++ b/service/broker/proto/broker.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -57,6 +58,8 @@ func NewBrokerService(name string) BrokerService {
 	return &brokerService{name: name}
 }
 
+var defaultBrokerService = NewBrokerService("broker")
+
 func (c *brokerService) Publish(ctx context.Context, in *PublishRequest, opts ...client.CallOption) (*Empty, error) {
 	req := microClient.NewRequest(c.name, "Broker.Publish", in)
 	out := new(Empty)
@@ -65,6 +68,10 @@ func (c *brokerService) Publish(ctx context.Context, in *PublishRequest, opts ..
 		return nil, err
 	}
 	return out, nil
+}
+
+func BrokerPublish(ctx context.Context, in *PublishRequest, opts ...client.CallOption) (*Empty, error) {
+	return defaultBrokerService.Publish(ctx, in, opts...)
 }
 
 func (c *brokerService) Subscribe(ctx context.Context, in *SubscribeRequest, opts ...client.CallOption) (Broker_SubscribeService, error) {
@@ -114,6 +121,10 @@ func (x *brokerServiceSubscribe) Recv() (*Message, error) {
 		return nil, err
 	}
 	return m, nil
+}
+
+func BrokerSubscribe(ctx context.Context, in *SubscribeRequest, opts ...client.CallOption) (Broker_SubscribeService, error) {
+	return defaultBrokerService.Subscribe(ctx, in, opts...)
 }
 
 // Server API for Broker service

--- a/service/config/proto/config.pb.micro.go
+++ b/service/config/proto/config.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -61,6 +62,8 @@ func NewConfigService(name string) ConfigService {
 	return &configService{name: name}
 }
 
+var defaultConfigService = NewConfigService("config")
+
 func (c *configService) Create(ctx context.Context, in *CreateRequest, opts ...client.CallOption) (*CreateResponse, error) {
 	req := microClient.NewRequest(c.name, "Config.Create", in)
 	out := new(CreateResponse)
@@ -69,6 +72,10 @@ func (c *configService) Create(ctx context.Context, in *CreateRequest, opts ...c
 		return nil, err
 	}
 	return out, nil
+}
+
+func ConfigCreate(ctx context.Context, in *CreateRequest, opts ...client.CallOption) (*CreateResponse, error) {
+	return defaultConfigService.Create(ctx, in, opts...)
 }
 
 func (c *configService) Update(ctx context.Context, in *UpdateRequest, opts ...client.CallOption) (*UpdateResponse, error) {
@@ -81,6 +88,10 @@ func (c *configService) Update(ctx context.Context, in *UpdateRequest, opts ...c
 	return out, nil
 }
 
+func ConfigUpdate(ctx context.Context, in *UpdateRequest, opts ...client.CallOption) (*UpdateResponse, error) {
+	return defaultConfigService.Update(ctx, in, opts...)
+}
+
 func (c *configService) Delete(ctx context.Context, in *DeleteRequest, opts ...client.CallOption) (*DeleteResponse, error) {
 	req := microClient.NewRequest(c.name, "Config.Delete", in)
 	out := new(DeleteResponse)
@@ -89,6 +100,10 @@ func (c *configService) Delete(ctx context.Context, in *DeleteRequest, opts ...c
 		return nil, err
 	}
 	return out, nil
+}
+
+func ConfigDelete(ctx context.Context, in *DeleteRequest, opts ...client.CallOption) (*DeleteResponse, error) {
+	return defaultConfigService.Delete(ctx, in, opts...)
 }
 
 func (c *configService) List(ctx context.Context, in *ListRequest, opts ...client.CallOption) (*ListResponse, error) {
@@ -101,6 +116,10 @@ func (c *configService) List(ctx context.Context, in *ListRequest, opts ...clien
 	return out, nil
 }
 
+func ConfigList(ctx context.Context, in *ListRequest, opts ...client.CallOption) (*ListResponse, error) {
+	return defaultConfigService.List(ctx, in, opts...)
+}
+
 func (c *configService) Read(ctx context.Context, in *ReadRequest, opts ...client.CallOption) (*ReadResponse, error) {
 	req := microClient.NewRequest(c.name, "Config.Read", in)
 	out := new(ReadResponse)
@@ -109,6 +128,10 @@ func (c *configService) Read(ctx context.Context, in *ReadRequest, opts ...clien
 		return nil, err
 	}
 	return out, nil
+}
+
+func ConfigRead(ctx context.Context, in *ReadRequest, opts ...client.CallOption) (*ReadResponse, error) {
+	return defaultConfigService.Read(ctx, in, opts...)
 }
 
 func (c *configService) Watch(ctx context.Context, in *WatchRequest, opts ...client.CallOption) (Config_WatchService, error) {
@@ -158,6 +181,10 @@ func (x *configServiceWatch) Recv() (*WatchResponse, error) {
 		return nil, err
 	}
 	return m, nil
+}
+
+func ConfigWatch(ctx context.Context, in *WatchRequest, opts ...client.CallOption) (Config_WatchService, error) {
+	return defaultConfigService.Watch(ctx, in, opts...)
 }
 
 // Server API for Config service

--- a/service/debug/log/proto/log.pb.micro.go
+++ b/service/debug/log/proto/log.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -56,6 +57,8 @@ func NewLogService(name string) LogService {
 	return &logService{name: name}
 }
 
+var defaultLogService = NewLogService("log")
+
 func (c *logService) Read(ctx context.Context, in *ReadRequest, opts ...client.CallOption) (*ReadResponse, error) {
 	req := microClient.NewRequest(c.name, "Log.Read", in)
 	out := new(ReadResponse)
@@ -64,6 +67,10 @@ func (c *logService) Read(ctx context.Context, in *ReadRequest, opts ...client.C
 		return nil, err
 	}
 	return out, nil
+}
+
+func LogRead(ctx context.Context, in *ReadRequest, opts ...client.CallOption) (*ReadResponse, error) {
+	return defaultLogService.Read(ctx, in, opts...)
 }
 
 // Server API for Log service

--- a/service/debug/stats/proto/debug.pb.micro.go
+++ b/service/debug/stats/proto/debug.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -58,6 +59,8 @@ func NewStatsService(name string) StatsService {
 	return &statsService{name: name}
 }
 
+var defaultStatsService = NewStatsService("stats")
+
 func (c *statsService) Read(ctx context.Context, in *ReadRequest, opts ...client.CallOption) (*ReadResponse, error) {
 	req := microClient.NewRequest(c.name, "Stats.Read", in)
 	out := new(ReadResponse)
@@ -68,6 +71,10 @@ func (c *statsService) Read(ctx context.Context, in *ReadRequest, opts ...client
 	return out, nil
 }
 
+func StatsRead(ctx context.Context, in *ReadRequest, opts ...client.CallOption) (*ReadResponse, error) {
+	return defaultStatsService.Read(ctx, in, opts...)
+}
+
 func (c *statsService) Write(ctx context.Context, in *WriteRequest, opts ...client.CallOption) (*WriteResponse, error) {
 	req := microClient.NewRequest(c.name, "Stats.Write", in)
 	out := new(WriteResponse)
@@ -76,6 +83,10 @@ func (c *statsService) Write(ctx context.Context, in *WriteRequest, opts ...clie
 		return nil, err
 	}
 	return out, nil
+}
+
+func StatsWrite(ctx context.Context, in *WriteRequest, opts ...client.CallOption) (*WriteResponse, error) {
+	return defaultStatsService.Write(ctx, in, opts...)
 }
 
 func (c *statsService) Stream(ctx context.Context, in *StreamRequest, opts ...client.CallOption) (Stats_StreamService, error) {
@@ -125,6 +136,10 @@ func (x *statsServiceStream) Recv() (*StreamResponse, error) {
 		return nil, err
 	}
 	return m, nil
+}
+
+func StatsStream(ctx context.Context, in *StreamRequest, opts ...client.CallOption) (Stats_StreamService, error) {
+	return defaultStatsService.Stream(ctx, in, opts...)
 }
 
 // Server API for Stats service

--- a/service/debug/trace/proto/trace.pb.micro.go
+++ b/service/debug/trace/proto/trace.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -58,6 +59,8 @@ func NewTraceService(name string) TraceService {
 	return &traceService{name: name}
 }
 
+var defaultTraceService = NewTraceService("trace")
+
 func (c *traceService) Read(ctx context.Context, in *ReadRequest, opts ...client.CallOption) (*ReadResponse, error) {
 	req := microClient.NewRequest(c.name, "Trace.Read", in)
 	out := new(ReadResponse)
@@ -68,6 +71,10 @@ func (c *traceService) Read(ctx context.Context, in *ReadRequest, opts ...client
 	return out, nil
 }
 
+func TraceRead(ctx context.Context, in *ReadRequest, opts ...client.CallOption) (*ReadResponse, error) {
+	return defaultTraceService.Read(ctx, in, opts...)
+}
+
 func (c *traceService) Write(ctx context.Context, in *WriteRequest, opts ...client.CallOption) (*WriteResponse, error) {
 	req := microClient.NewRequest(c.name, "Trace.Write", in)
 	out := new(WriteResponse)
@@ -76,6 +83,10 @@ func (c *traceService) Write(ctx context.Context, in *WriteRequest, opts ...clie
 		return nil, err
 	}
 	return out, nil
+}
+
+func TraceWrite(ctx context.Context, in *WriteRequest, opts ...client.CallOption) (*WriteResponse, error) {
+	return defaultTraceService.Write(ctx, in, opts...)
 }
 
 func (c *traceService) Stream(ctx context.Context, in *StreamRequest, opts ...client.CallOption) (Trace_StreamService, error) {
@@ -125,6 +136,10 @@ func (x *traceServiceStream) Recv() (*StreamResponse, error) {
 		return nil, err
 	}
 	return m, nil
+}
+
+func TraceStream(ctx context.Context, in *StreamRequest, opts ...client.CallOption) (Trace_StreamService, error) {
+	return defaultTraceService.Stream(ctx, in, opts...)
 }
 
 // Server API for Trace service

--- a/service/network/proto/network.pb.micro.go
+++ b/service/network/proto/network.pb.micro.go
@@ -34,6 +34,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -68,6 +69,8 @@ func NewNetworkService(name string) NetworkService {
 	return &networkService{name: name}
 }
 
+var defaultNetworkService = NewNetworkService("network")
+
 func (c *networkService) Connect(ctx context.Context, in *ConnectRequest, opts ...client.CallOption) (*ConnectResponse, error) {
 	req := microClient.NewRequest(c.name, "Network.Connect", in)
 	out := new(ConnectResponse)
@@ -76,6 +79,10 @@ func (c *networkService) Connect(ctx context.Context, in *ConnectRequest, opts .
 		return nil, err
 	}
 	return out, nil
+}
+
+func NetworkConnect(ctx context.Context, in *ConnectRequest, opts ...client.CallOption) (*ConnectResponse, error) {
+	return defaultNetworkService.Connect(ctx, in, opts...)
 }
 
 func (c *networkService) Graph(ctx context.Context, in *GraphRequest, opts ...client.CallOption) (*GraphResponse, error) {
@@ -88,6 +95,10 @@ func (c *networkService) Graph(ctx context.Context, in *GraphRequest, opts ...cl
 	return out, nil
 }
 
+func NetworkGraph(ctx context.Context, in *GraphRequest, opts ...client.CallOption) (*GraphResponse, error) {
+	return defaultNetworkService.Graph(ctx, in, opts...)
+}
+
 func (c *networkService) Nodes(ctx context.Context, in *NodesRequest, opts ...client.CallOption) (*NodesResponse, error) {
 	req := microClient.NewRequest(c.name, "Network.Nodes", in)
 	out := new(NodesResponse)
@@ -96,6 +107,10 @@ func (c *networkService) Nodes(ctx context.Context, in *NodesRequest, opts ...cl
 		return nil, err
 	}
 	return out, nil
+}
+
+func NetworkNodes(ctx context.Context, in *NodesRequest, opts ...client.CallOption) (*NodesResponse, error) {
+	return defaultNetworkService.Nodes(ctx, in, opts...)
 }
 
 func (c *networkService) Routes(ctx context.Context, in *RoutesRequest, opts ...client.CallOption) (*RoutesResponse, error) {
@@ -108,6 +123,10 @@ func (c *networkService) Routes(ctx context.Context, in *RoutesRequest, opts ...
 	return out, nil
 }
 
+func NetworkRoutes(ctx context.Context, in *RoutesRequest, opts ...client.CallOption) (*RoutesResponse, error) {
+	return defaultNetworkService.Routes(ctx, in, opts...)
+}
+
 func (c *networkService) Services(ctx context.Context, in *ServicesRequest, opts ...client.CallOption) (*ServicesResponse, error) {
 	req := microClient.NewRequest(c.name, "Network.Services", in)
 	out := new(ServicesResponse)
@@ -118,6 +137,10 @@ func (c *networkService) Services(ctx context.Context, in *ServicesRequest, opts
 	return out, nil
 }
 
+func NetworkServices(ctx context.Context, in *ServicesRequest, opts ...client.CallOption) (*ServicesResponse, error) {
+	return defaultNetworkService.Services(ctx, in, opts...)
+}
+
 func (c *networkService) Status(ctx context.Context, in *StatusRequest, opts ...client.CallOption) (*StatusResponse, error) {
 	req := microClient.NewRequest(c.name, "Network.Status", in)
 	out := new(StatusResponse)
@@ -126,6 +149,10 @@ func (c *networkService) Status(ctx context.Context, in *StatusRequest, opts ...
 		return nil, err
 	}
 	return out, nil
+}
+
+func NetworkStatus(ctx context.Context, in *StatusRequest, opts ...client.CallOption) (*StatusResponse, error) {
+	return defaultNetworkService.Status(ctx, in, opts...)
 }
 
 // Server API for Network service

--- a/service/registry/proto/registry.pb.micro.go
+++ b/service/registry/proto/registry.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -60,6 +61,8 @@ func NewRegistryService(name string) RegistryService {
 	return &registryService{name: name}
 }
 
+var defaultRegistryService = NewRegistryService("registry")
+
 func (c *registryService) GetService(ctx context.Context, in *GetRequest, opts ...client.CallOption) (*GetResponse, error) {
 	req := microClient.NewRequest(c.name, "Registry.GetService", in)
 	out := new(GetResponse)
@@ -68,6 +71,10 @@ func (c *registryService) GetService(ctx context.Context, in *GetRequest, opts .
 		return nil, err
 	}
 	return out, nil
+}
+
+func RegistryGetService(ctx context.Context, in *GetRequest, opts ...client.CallOption) (*GetResponse, error) {
+	return defaultRegistryService.GetService(ctx, in, opts...)
 }
 
 func (c *registryService) Register(ctx context.Context, in *Service, opts ...client.CallOption) (*EmptyResponse, error) {
@@ -80,6 +87,10 @@ func (c *registryService) Register(ctx context.Context, in *Service, opts ...cli
 	return out, nil
 }
 
+func RegistryRegister(ctx context.Context, in *Service, opts ...client.CallOption) (*EmptyResponse, error) {
+	return defaultRegistryService.Register(ctx, in, opts...)
+}
+
 func (c *registryService) Deregister(ctx context.Context, in *Service, opts ...client.CallOption) (*EmptyResponse, error) {
 	req := microClient.NewRequest(c.name, "Registry.Deregister", in)
 	out := new(EmptyResponse)
@@ -90,6 +101,10 @@ func (c *registryService) Deregister(ctx context.Context, in *Service, opts ...c
 	return out, nil
 }
 
+func RegistryDeregister(ctx context.Context, in *Service, opts ...client.CallOption) (*EmptyResponse, error) {
+	return defaultRegistryService.Deregister(ctx, in, opts...)
+}
+
 func (c *registryService) ListServices(ctx context.Context, in *ListRequest, opts ...client.CallOption) (*ListResponse, error) {
 	req := microClient.NewRequest(c.name, "Registry.ListServices", in)
 	out := new(ListResponse)
@@ -98,6 +113,10 @@ func (c *registryService) ListServices(ctx context.Context, in *ListRequest, opt
 		return nil, err
 	}
 	return out, nil
+}
+
+func RegistryListServices(ctx context.Context, in *ListRequest, opts ...client.CallOption) (*ListResponse, error) {
+	return defaultRegistryService.ListServices(ctx, in, opts...)
 }
 
 func (c *registryService) Watch(ctx context.Context, in *WatchRequest, opts ...client.CallOption) (Registry_WatchService, error) {
@@ -147,6 +166,10 @@ func (x *registryServiceWatch) Recv() (*Result, error) {
 		return nil, err
 	}
 	return m, nil
+}
+
+func RegistryWatch(ctx context.Context, in *WatchRequest, opts ...client.CallOption) (Registry_WatchService, error) {
+	return defaultRegistryService.Watch(ctx, in, opts...)
 }
 
 // Server API for Registry service

--- a/service/router/proto/router.pb.micro.go
+++ b/service/router/proto/router.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -59,6 +60,8 @@ func NewRouterService(name string) RouterService {
 	return &routerService{name: name}
 }
 
+var defaultRouterService = NewRouterService("router")
+
 func (c *routerService) Lookup(ctx context.Context, in *LookupRequest, opts ...client.CallOption) (*LookupResponse, error) {
 	req := microClient.NewRequest(c.name, "Router.Lookup", in)
 	out := new(LookupResponse)
@@ -67,6 +70,10 @@ func (c *routerService) Lookup(ctx context.Context, in *LookupRequest, opts ...c
 		return nil, err
 	}
 	return out, nil
+}
+
+func RouterLookup(ctx context.Context, in *LookupRequest, opts ...client.CallOption) (*LookupResponse, error) {
+	return defaultRouterService.Lookup(ctx, in, opts...)
 }
 
 func (c *routerService) Watch(ctx context.Context, in *WatchRequest, opts ...client.CallOption) (Router_WatchService, error) {
@@ -118,6 +125,10 @@ func (x *routerServiceWatch) Recv() (*Event, error) {
 	return m, nil
 }
 
+func RouterWatch(ctx context.Context, in *WatchRequest, opts ...client.CallOption) (Router_WatchService, error) {
+	return defaultRouterService.Watch(ctx, in, opts...)
+}
+
 func (c *routerService) Advertise(ctx context.Context, in *Request, opts ...client.CallOption) (Router_AdvertiseService, error) {
 	req := microClient.NewRequest(c.name, "Router.Advertise", &Request{})
 	stream, err := microClient.Stream(ctx, req, opts...)
@@ -167,6 +178,10 @@ func (x *routerServiceAdvertise) Recv() (*Advert, error) {
 	return m, nil
 }
 
+func RouterAdvertise(ctx context.Context, in *Request, opts ...client.CallOption) (Router_AdvertiseService, error) {
+	return defaultRouterService.Advertise(ctx, in, opts...)
+}
+
 func (c *routerService) Process(ctx context.Context, in *Advert, opts ...client.CallOption) (*ProcessResponse, error) {
 	req := microClient.NewRequest(c.name, "Router.Process", in)
 	out := new(ProcessResponse)
@@ -175,6 +190,10 @@ func (c *routerService) Process(ctx context.Context, in *Advert, opts ...client.
 		return nil, err
 	}
 	return out, nil
+}
+
+func RouterProcess(ctx context.Context, in *Advert, opts ...client.CallOption) (*ProcessResponse, error) {
+	return defaultRouterService.Process(ctx, in, opts...)
 }
 
 // Server API for Router service
@@ -316,6 +335,8 @@ func NewTableService(name string) TableService {
 	return &tableService{name: name}
 }
 
+var defaultTableService = NewTableService("table")
+
 func (c *tableService) Create(ctx context.Context, in *Route, opts ...client.CallOption) (*CreateResponse, error) {
 	req := microClient.NewRequest(c.name, "Table.Create", in)
 	out := new(CreateResponse)
@@ -324,6 +345,10 @@ func (c *tableService) Create(ctx context.Context, in *Route, opts ...client.Cal
 		return nil, err
 	}
 	return out, nil
+}
+
+func TableCreate(ctx context.Context, in *Route, opts ...client.CallOption) (*CreateResponse, error) {
+	return defaultTableService.Create(ctx, in, opts...)
 }
 
 func (c *tableService) Delete(ctx context.Context, in *Route, opts ...client.CallOption) (*DeleteResponse, error) {
@@ -336,6 +361,10 @@ func (c *tableService) Delete(ctx context.Context, in *Route, opts ...client.Cal
 	return out, nil
 }
 
+func TableDelete(ctx context.Context, in *Route, opts ...client.CallOption) (*DeleteResponse, error) {
+	return defaultTableService.Delete(ctx, in, opts...)
+}
+
 func (c *tableService) Update(ctx context.Context, in *Route, opts ...client.CallOption) (*UpdateResponse, error) {
 	req := microClient.NewRequest(c.name, "Table.Update", in)
 	out := new(UpdateResponse)
@@ -344,6 +373,10 @@ func (c *tableService) Update(ctx context.Context, in *Route, opts ...client.Cal
 		return nil, err
 	}
 	return out, nil
+}
+
+func TableUpdate(ctx context.Context, in *Route, opts ...client.CallOption) (*UpdateResponse, error) {
+	return defaultTableService.Update(ctx, in, opts...)
 }
 
 func (c *tableService) List(ctx context.Context, in *Request, opts ...client.CallOption) (*ListResponse, error) {
@@ -356,6 +389,10 @@ func (c *tableService) List(ctx context.Context, in *Request, opts ...client.Cal
 	return out, nil
 }
 
+func TableList(ctx context.Context, in *Request, opts ...client.CallOption) (*ListResponse, error) {
+	return defaultTableService.List(ctx, in, opts...)
+}
+
 func (c *tableService) Query(ctx context.Context, in *QueryRequest, opts ...client.CallOption) (*QueryResponse, error) {
 	req := microClient.NewRequest(c.name, "Table.Query", in)
 	out := new(QueryResponse)
@@ -364,6 +401,10 @@ func (c *tableService) Query(ctx context.Context, in *QueryRequest, opts ...clie
 		return nil, err
 	}
 	return out, nil
+}
+
+func TableQuery(ctx context.Context, in *QueryRequest, opts ...client.CallOption) (*QueryResponse, error) {
+	return defaultTableService.Query(ctx, in, opts...)
 }
 
 // Server API for Table service

--- a/service/runtime/proto/runtime.pb.micro.go
+++ b/service/runtime/proto/runtime.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -60,6 +61,8 @@ func NewRuntimeService(name string) RuntimeService {
 	return &runtimeService{name: name}
 }
 
+var defaultRuntimeService = NewRuntimeService("runtime")
+
 func (c *runtimeService) Create(ctx context.Context, in *CreateRequest, opts ...client.CallOption) (*CreateResponse, error) {
 	req := microClient.NewRequest(c.name, "Runtime.Create", in)
 	out := new(CreateResponse)
@@ -68,6 +71,10 @@ func (c *runtimeService) Create(ctx context.Context, in *CreateRequest, opts ...
 		return nil, err
 	}
 	return out, nil
+}
+
+func RuntimeCreate(ctx context.Context, in *CreateRequest, opts ...client.CallOption) (*CreateResponse, error) {
+	return defaultRuntimeService.Create(ctx, in, opts...)
 }
 
 func (c *runtimeService) Read(ctx context.Context, in *ReadRequest, opts ...client.CallOption) (*ReadResponse, error) {
@@ -80,6 +87,10 @@ func (c *runtimeService) Read(ctx context.Context, in *ReadRequest, opts ...clie
 	return out, nil
 }
 
+func RuntimeRead(ctx context.Context, in *ReadRequest, opts ...client.CallOption) (*ReadResponse, error) {
+	return defaultRuntimeService.Read(ctx, in, opts...)
+}
+
 func (c *runtimeService) Delete(ctx context.Context, in *DeleteRequest, opts ...client.CallOption) (*DeleteResponse, error) {
 	req := microClient.NewRequest(c.name, "Runtime.Delete", in)
 	out := new(DeleteResponse)
@@ -90,6 +101,10 @@ func (c *runtimeService) Delete(ctx context.Context, in *DeleteRequest, opts ...
 	return out, nil
 }
 
+func RuntimeDelete(ctx context.Context, in *DeleteRequest, opts ...client.CallOption) (*DeleteResponse, error) {
+	return defaultRuntimeService.Delete(ctx, in, opts...)
+}
+
 func (c *runtimeService) Update(ctx context.Context, in *UpdateRequest, opts ...client.CallOption) (*UpdateResponse, error) {
 	req := microClient.NewRequest(c.name, "Runtime.Update", in)
 	out := new(UpdateResponse)
@@ -98,6 +113,10 @@ func (c *runtimeService) Update(ctx context.Context, in *UpdateRequest, opts ...
 		return nil, err
 	}
 	return out, nil
+}
+
+func RuntimeUpdate(ctx context.Context, in *UpdateRequest, opts ...client.CallOption) (*UpdateResponse, error) {
+	return defaultRuntimeService.Update(ctx, in, opts...)
 }
 
 func (c *runtimeService) Logs(ctx context.Context, in *LogsRequest, opts ...client.CallOption) (Runtime_LogsService, error) {
@@ -147,6 +166,10 @@ func (x *runtimeServiceLogs) Recv() (*LogRecord, error) {
 		return nil, err
 	}
 	return m, nil
+}
+
+func RuntimeLogs(ctx context.Context, in *LogsRequest, opts ...client.CallOption) (Runtime_LogsService, error) {
+	return defaultRuntimeService.Logs(ctx, in, opts...)
 }
 
 // Server API for Runtime service

--- a/service/store/proto/store.pb.micro.go
+++ b/service/store/proto/store.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -61,6 +62,8 @@ func NewStoreService(name string) StoreService {
 	return &storeService{name: name}
 }
 
+var defaultStoreService = NewStoreService("store")
+
 func (c *storeService) Read(ctx context.Context, in *ReadRequest, opts ...client.CallOption) (*ReadResponse, error) {
 	req := microClient.NewRequest(c.name, "Store.Read", in)
 	out := new(ReadResponse)
@@ -69,6 +72,10 @@ func (c *storeService) Read(ctx context.Context, in *ReadRequest, opts ...client
 		return nil, err
 	}
 	return out, nil
+}
+
+func StoreRead(ctx context.Context, in *ReadRequest, opts ...client.CallOption) (*ReadResponse, error) {
+	return defaultStoreService.Read(ctx, in, opts...)
 }
 
 func (c *storeService) Write(ctx context.Context, in *WriteRequest, opts ...client.CallOption) (*WriteResponse, error) {
@@ -81,6 +88,10 @@ func (c *storeService) Write(ctx context.Context, in *WriteRequest, opts ...clie
 	return out, nil
 }
 
+func StoreWrite(ctx context.Context, in *WriteRequest, opts ...client.CallOption) (*WriteResponse, error) {
+	return defaultStoreService.Write(ctx, in, opts...)
+}
+
 func (c *storeService) Delete(ctx context.Context, in *DeleteRequest, opts ...client.CallOption) (*DeleteResponse, error) {
 	req := microClient.NewRequest(c.name, "Store.Delete", in)
 	out := new(DeleteResponse)
@@ -89,6 +100,10 @@ func (c *storeService) Delete(ctx context.Context, in *DeleteRequest, opts ...cl
 		return nil, err
 	}
 	return out, nil
+}
+
+func StoreDelete(ctx context.Context, in *DeleteRequest, opts ...client.CallOption) (*DeleteResponse, error) {
+	return defaultStoreService.Delete(ctx, in, opts...)
 }
 
 func (c *storeService) List(ctx context.Context, in *ListRequest, opts ...client.CallOption) (Store_ListService, error) {
@@ -140,6 +155,10 @@ func (x *storeServiceList) Recv() (*ListResponse, error) {
 	return m, nil
 }
 
+func StoreList(ctx context.Context, in *ListRequest, opts ...client.CallOption) (Store_ListService, error) {
+	return defaultStoreService.List(ctx, in, opts...)
+}
+
 func (c *storeService) Databases(ctx context.Context, in *DatabasesRequest, opts ...client.CallOption) (*DatabasesResponse, error) {
 	req := microClient.NewRequest(c.name, "Store.Databases", in)
 	out := new(DatabasesResponse)
@@ -150,6 +169,10 @@ func (c *storeService) Databases(ctx context.Context, in *DatabasesRequest, opts
 	return out, nil
 }
 
+func StoreDatabases(ctx context.Context, in *DatabasesRequest, opts ...client.CallOption) (*DatabasesResponse, error) {
+	return defaultStoreService.Databases(ctx, in, opts...)
+}
+
 func (c *storeService) Tables(ctx context.Context, in *TablesRequest, opts ...client.CallOption) (*TablesResponse, error) {
 	req := microClient.NewRequest(c.name, "Store.Tables", in)
 	out := new(TablesResponse)
@@ -158,6 +181,10 @@ func (c *storeService) Tables(ctx context.Context, in *TablesRequest, opts ...cl
 		return nil, err
 	}
 	return out, nil
+}
+
+func StoreTables(ctx context.Context, in *TablesRequest, opts ...client.CallOption) (*TablesResponse, error) {
+	return defaultStoreService.Tables(ctx, in, opts...)
 }
 
 // Server API for Store service

--- a/test/dep-test/dep-test-service/proto/dep/dep.pb.micro.go
+++ b/test/dep-test/dep-test-service/proto/dep/dep.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -58,6 +59,8 @@ func NewDepService(name string) DepService {
 	return &depService{name: name}
 }
 
+var defaultDepService = NewDepService("dep")
+
 func (c *depService) Call(ctx context.Context, in *Request, opts ...client.CallOption) (*Response, error) {
 	req := microClient.NewRequest(c.name, "Dep.Call", in)
 	out := new(Response)
@@ -66,6 +69,10 @@ func (c *depService) Call(ctx context.Context, in *Request, opts ...client.CallO
 		return nil, err
 	}
 	return out, nil
+}
+
+func DepCall(ctx context.Context, in *Request, opts ...client.CallOption) (*Response, error) {
+	return defaultDepService.Call(ctx, in, opts...)
 }
 
 func (c *depService) Stream(ctx context.Context, in *StreamingRequest, opts ...client.CallOption) (Dep_StreamService, error) {
@@ -117,6 +124,10 @@ func (x *depServiceStream) Recv() (*StreamingResponse, error) {
 	return m, nil
 }
 
+func DepStream(ctx context.Context, in *StreamingRequest, opts ...client.CallOption) (Dep_StreamService, error) {
+	return defaultDepService.Stream(ctx, in, opts...)
+}
+
 func (c *depService) PingPong(ctx context.Context, opts ...client.CallOption) (Dep_PingPongService, error) {
 	req := microClient.NewRequest(c.name, "Dep.PingPong", &Ping{})
 	stream, err := microClient.Stream(ctx, req, opts...)
@@ -166,6 +177,10 @@ func (x *depServicePingPong) Recv() (*Pong, error) {
 		return nil, err
 	}
 	return m, nil
+}
+
+func DepPingPong(ctx context.Context, opts ...client.CallOption) (Dep_PingPongService, error) {
+	return defaultDepService.PingPong(ctx, opts...)
 }
 
 // Server API for Dep service

--- a/test/service/example/proto/example.pb.micro.go
+++ b/test/service/example/proto/example.pb.micro.go
@@ -33,6 +33,7 @@ const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 var _ api.Endpoint
 var _ context.Context
 var _ client.Option
+var _ server.Option
 var _ = microServer.Handle
 var _ = microClient.Call
 
@@ -56,6 +57,8 @@ func NewExampleService(name string) ExampleService {
 	return &exampleService{name: name}
 }
 
+var defaultExampleService = NewExampleService("example")
+
 func (c *exampleService) Call(ctx context.Context, in *Request, opts ...client.CallOption) (*Response, error) {
 	req := microClient.NewRequest(c.name, "Example.Call", in)
 	out := new(Response)
@@ -64,6 +67,10 @@ func (c *exampleService) Call(ctx context.Context, in *Request, opts ...client.C
 		return nil, err
 	}
 	return out, nil
+}
+
+func ExampleCall(ctx context.Context, in *Request, opts ...client.CallOption) (*Response, error) {
+	return defaultExampleService.Call(ctx, in, opts...)
 }
 
 // Server API for Example service


### PR DESCRIPTION
As well as:
```
cli := pb.NewPostsService("posts")
rsp, err := cli.Create(ctx, req)
```

you can now also do:
```
rsp, err := pb.PostsCreate(ctx, req)
```