### PR TITLE
Fix dynamic commands

### DIFF
--- a/service/registry/server/handler.go
+++ b/service/registry/server/handler.go
@@ -72,7 +72,7 @@ func (r *Registry) GetService(ctx context.Context, req *pb.GetRequest, rsp *pb.G
 
 	// get the services in the namespace
 	services, err := registry.GetService(req.Service, goregistry.GetDomain(options.Domain))
-	if err == goregistry.ErrNotFound {
+	if err == goregistry.ErrNotFound || len(services) == 0 {
 		return errors.NotFound("registry.Registry.GetService", err.Error())
 	} else if err != nil {
 		return errors.InternalServerError("registry.Registry.GetService", err.Error())


### PR DESCRIPTION
Example usage:

```bash
micro@Bens-MacBook-Pro-3 micro % go run . registry getService --service=helloworld
{
	"services": [
		{
			"name": "helloworld",
			"version": "latest",
			"endpoints": [
				{
					"name": "Helloworld.Call",
					"request": {
						"name": "Request",
						"type": "Request",
						"values": [
							{
								"name": "name",
								"type": "string"
							}
						]
					},
					"response": {
						"name": "Response",
						"type": "Response",
						"values": [
							{
								"name": "msg",
								"type": "string"
							}
						]
					}
				}
			],
			"nodes": [
				{
					"id": "helloworld-144f35cd-8e35-46b6-94ca-9ba671f1a9c0",
					"address": "192.168.1.174:54220",
					"metadata": {
						"broker": "http",
						"protocol": "grpc",
						"registry": "service",
						"server": "grpc",
						"transport": "grpc"
					}
				}
			],
			"options": {}
		}
	]
}
```