### PR TITLE
cmd: fix proxy address not being set for micro services (e.g. client)

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -256,7 +256,7 @@ func (c *command) Before(ctx *cli.Context) error {
 
 	// set the proxy address
 	var proxy string
-	if c.service {
+	if c.service || ctx.IsSet("proxy_address") {
 		// use the proxy address passed as a flag, this is normally
 		// the micro network
 		proxy = ctx.String("proxy_address")


### PR DESCRIPTION
micro services don't get included in `c.service` since the cmd package is not configured by the service package.  This resulted in the proxy not being set for clients, e.g. the proxy.