### PR TITLE
check args before execute setEnv

### DIFF
--- a/client/cli/helpers.go
+++ b/client/cli/helpers.go
@@ -31,6 +31,9 @@ func getEnv(c *cli.Context, args []string) ([]byte, error) {
 }
 
 func setEnv(c *cli.Context, args []string) ([]byte, error) {
+	if len(args) == 0 {
+		return nil, errors.New("name required")
+	}
 	cliutil.SetEnv(args[0])
 	return nil, nil
 }


### PR DESCRIPTION
logs:
shlande@MacBook-Pro util % micro env set
panic: runtime error: index out of range [0] with length 0

