### PR TITLE
github/workflows: tag each docker image with the git ref

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,10 +20,14 @@ jobs:
     - name: Fetch tags
       run: git fetch --prune --unshallow
 
+    - name: Get release version
+      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: micro/micro
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "latest,${{ env.RELEASE_VERSION }}"
         tag_names: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,5 +29,5 @@ jobs:
         name: micro/micro
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "latest,${{ env.RELEASE_VERSION }}"
+        tags: ${{ env.RELEASE_VERSION }}
         tag_names: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,14 +20,11 @@ jobs:
     - name: Fetch tags
       run: git fetch --prune --unshallow
 
-    - name: Get release version
-      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
-
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: micro/micro
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: ${{ env.RELEASE_VERSION }}
         tag_names: true
+        snapshot: true


### PR DESCRIPTION
In order to do k8s rolling updates, we need to have a unique tag per image. 

See:
• https://kubernetes.io/docs/tutorials/kubernetes-basics/update/update-intro/
• https://github.com/elgohr/Publish-Docker-Github-Action#tags-1