### PR TITLE
{cmd/service}: add service_address flag

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -177,6 +177,11 @@ var (
 			Usage:   "Version of the micro service",
 			EnvVars: []string{"MICRO_SERVICE_VERSION"},
 		},
+		&cli.StringFlag{
+			Name:    "service_address",
+			Usage:   "Address to run the service on",
+			EnvVars: []string{"MICRO_SERVICE_ADDRESS"},
+		},
 	}
 )
 

--- a/service/service.go
+++ b/service/service.go
@@ -60,6 +60,9 @@ func New(opts ...Option) *Service {
 		if v := ctx.String("service_version"); len(v) > 0 {
 			opts = append([]Option{Version(v)}, opts...)
 		}
+		if a := ctx.String("service_address"); len(a) > 0 {
+			opts = append([]Option{Address(a)}, opts...)
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Add a service_address flag, which allows setting the port to bind to. This will enable readiness checks in k8s.