### PR TITLE
runtime/cli: improve error output

### DIFF
--- a/service/runtime/cli/service.go
+++ b/service/runtime/cli/service.go
@@ -431,14 +431,20 @@ func getService(ctx *cli.Context) error {
 	fmt.Fprintln(writer, "NAME\tVERSION\tSOURCE\tSTATUS\tBUILD\tUPDATED\tMETADATA")
 	for _, service := range services {
 		status := parse(service.Metadata["status"])
-		if status == "error" {
-			status = service.Metadata["error"]
-		}
 
 		// cut the commit down to first 7 characters
 		build := parse(service.Metadata["build"])
 		if len(build) > 7 {
 			build = build[:7]
+		}
+
+		// if there is an error, display this in metadata (there is no error field), otherwise
+		// display the owner and the group
+		var metadata string
+		if status == "error" {
+			metadata = fmt.Sprintf("error=%v", service.Metadata["error"])
+		} else {
+			metadata = fmt.Sprintf("owner=%s, group=%s", parse(service.Metadata["owner"]), parse(service.Metadata["group"]))
 		}
 
 		// parse when the service was started
@@ -451,7 +457,7 @@ func getService(ctx *cli.Context) error {
 			strings.ToLower(status),
 			build,
 			updated,
-			fmt.Sprintf("owner=%s,group=%s", parse(service.Metadata["owner"]), parse(service.Metadata["group"])))
+			metadata)
 	}
 	writer.Flush()
 	return nil

--- a/service/runtime/cli/service.go
+++ b/service/runtime/cli/service.go
@@ -438,13 +438,10 @@ func getService(ctx *cli.Context) error {
 			build = build[:7]
 		}
 
-		// if there is an error, display this in metadata (there is no error field), otherwise
-		// display the owner and the group
-		var metadata string
+		// if there is an error, display this in metadata (there is no error field)
+		metadata := fmt.Sprintf("owner=%s, group=%s", parse(service.Metadata["owner"]), parse(service.Metadata["group"]))
 		if status == "error" {
-			metadata = fmt.Sprintf("error=%v", service.Metadata["error"])
-		} else {
-			metadata = fmt.Sprintf("owner=%s, group=%s", parse(service.Metadata["owner"]), parse(service.Metadata["group"]))
+			metadata = fmt.Sprintf("%v, error=%v", metadata, parse(service.Metadata["error"]))
 		}
 
 		// parse when the service was started


### PR DESCRIPTION
Previously:
```bash
$ micro run github.com/micro/services/helloworld
$ micro status
NAME		VERSION	SOURCE		STATUS	
helloworld	latest	helloworld	post https://10.32.0.1:443/apis/apps/v1/namespaces/debatable-plod-puritan/deployments/: eof	n/a	unknown	owner=n/a,group=n/a
```

Now:
```bash
$ micro run github.com/micro/services/helloworld
$ micro status
NAME		VERSION	SOURCE		STATUS	ERROR
helloworld	latest	helloworld	error	post https://10.32.0.1:443/apis/apps/v1/namespaces/debatable-plod-puritan/deployments/: eof
```

Closes: https://github.com/m3o/dev/issues/334.  It appears the actual underlying error in the issue is just a flake with connecting to kubernetes. The runtime manager will automatically retry this.