### PR TITLE
test: add namespace as option to test framework

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -83,7 +83,7 @@ To run the k8s integration tests locally you need to first install the pre-reqs:
 The tests can then be run:
 1. `kind create cluster` - create the cluster
 2. `./scripts/kind-launch.sh` - install micro in to the cluster
-3. `cd tests && go clean -testcache && IN_TRAVIS_CI=yes go test --tags=integration,kind -v ./...` - run the tests
+3. `cd test && go clean -testcache && IN_TRAVIS_CI=yes go test --tags=integration,kind -v ./...` - run the tests
 
 #### Adding more tests
 Not all integration tests use a server so only a subset of the tests need to run against our Kind cluster. New tests should be defined in the usual way and then added to the `testFilter` slice defined near the top of [kind.go](kind.go). This is the list of all tests to be run against Kind. 

--- a/test/kind.go
+++ b/test/kind.go
@@ -26,7 +26,10 @@ func init() {
 }
 
 func newK8sServer(t *T, fname string, opts ...Option) Server {
-	var options Options
+	options := Options{
+		Namespace: strings.ToLower(fname),
+		Login:     false,
+	}
 	for _, o := range opts {
 		o(&options)
 	}
@@ -38,7 +41,7 @@ func newK8sServer(t *T, fname string, opts ...Option) Server {
 		dir:       filepath.Dir(configFile),
 		config:    configFile,
 		t:         t,
-		env:       strings.ToLower(fname),
+		env:       options.Namespace,
 		proxyPort: portnum,
 		opts:      options,
 		cmd:       exec.Command("kubectl", "port-forward", "--namespace", "default", "svc/micro-proxy", fmt.Sprintf("%d:443", portnum)),

--- a/test/test_framework.go
+++ b/test/test_framework.go
@@ -229,6 +229,8 @@ func myCaller() string {
 type Options struct {
 	// Login specifies whether to login to the server
 	Login bool
+	// Namespace to use, defaults to the test name
+	Namespace string
 }
 
 type Option func(o *Options)
@@ -236,6 +238,12 @@ type Option func(o *Options)
 func WithLogin() Option {
 	return func(o *Options) {
 		o.Login = true
+	}
+}
+
+func WithNamespace(ns string) Option {
+	return func(o *Options) {
+		o.Namespace = ns
 	}
 }
 
@@ -253,7 +261,10 @@ type ServerDefault struct {
 }
 
 func newLocalServer(t *T, fname string, opts ...Option) Server {
-	var options Options
+	options := Options{
+		Namespace: fname,
+		Login:     false,
+	}
 	for _, o := range opts {
 		o(&options)
 	}
@@ -301,7 +312,7 @@ func newLocalServer(t *T, fname string, opts ...Option) Server {
 		config:    configFile,
 		cmd:       cmd,
 		t:         t,
-		env:       fname,
+		env:       options.Namespace,
 		container: fname,
 		apiPort:   apiPortNum,
 		proxyPort: proxyPortnum,


### PR DESCRIPTION
some tests require services to be run in a specific namespace (e.g. running events test service in the micro namespace). This PR enables that functionality.