### PR TITLE
Use MDNS in the test rather than etcd

### DIFF
--- a/profile/profile.go
+++ b/profile/profile.go
@@ -100,7 +100,7 @@ var CI = &Profile{
 		microEvents.DefaultStream, _ = memStream.NewStream()
 		microEvents.DefaultStore = evStore.NewStore(evStore.WithStore(microStore.DefaultStore))
 		setBroker(http.NewBroker())
-		setRegistry(etcd.NewRegistry())
+		setRegistry(mdns.NewRegistry())
 		setupJWTRules()
 		return nil
 	},

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -8,26 +8,21 @@ ENV PATH /go/bin:$PATH
 
 RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin
 
+RUN apt-get update && \
+    apt-get install -yq \
+      avahi-daemon avahi-utils libnss-mdns
+
+RUN systemctl enable avahi-daemon
+
 RUN apk add ca-certificates && \
     rm -rf /var/cache/apk/* /tmp/* && \
     [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
-
-RUN         apk add --update ca-certificates openssl tar && \
-            wget https://github.com/coreos/etcd/releases/download/v3.4.7/etcd-v3.4.7-linux-amd64.tar.gz && \
-            tar xzvf etcd-v3.4.7-linux-amd64.tar.gz && \
-            mv etcd-v3.4.7-linux-amd64/etcd* /bin/ && \
-            apk del --purge tar openssl && \
-            rm -Rf etcd-v3.4.7-linux-amd64* /var/cache/apk/*
-VOLUME      /data
-EXPOSE      2379 2380 4001 7001
 ADD         scripts/run-etcd.sh /bin/run.sh
 
-ENV MICRO_REGISTRY=etcd
-
-# Speeding up tests by predownloading and building dependencies for services used.
+# Speed up tests by predownloading and building dependencies for services used.
 COPY . .
 RUN go get github.com/micro/services
 RUN go get github.com/micro/services/helloworld
 RUN bash -c 'for d in $(find test -name "main.go" | xargs -n 1 dirname); do pushd $d && go get && popd; done'
 COPY ./micro /micro
-ENTRYPOINT ["sh", "/bin/run.sh"]
+ENTRYPOINT ["/micro"]

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin
 
 RUN apk add avahi avahi-tools
 
-RUN echo -e '!#/bin/bash\navahi-daemon &' > run.sh && chmod +x run.sh && ./run.sh
+RUN echo -e '#!/bin/bash\navahi-daemon &' > run.sh && chmod +x run.sh && ./run.sh
 
 RUN apk add ca-certificates && \
     rm -rf /var/cache/apk/* /tmp/* && \

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH /go/bin:$PATH
 
 RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin
 
-RUN apk add avahi-daemon avahi-utils libnss-mdns
+RUN apk add avahi avahi-tools
 
 RUN systemctl enable avahi-daemon
 

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin
 
 RUN apk add avahi avahi-tools
 
-RUN systemctl enable avahi-daemon
+RUN echo -e '!#/bin/bash\navahi-daemon &' > run.sh && chmod +x run.sh && ./run.sh
 
 RUN apk add ca-certificates && \
     rm -rf /var/cache/apk/* /tmp/* && \

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -8,9 +8,7 @@ ENV PATH /go/bin:$PATH
 
 RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin
 
-RUN apt-get update && \
-    apt-get install -yq \
-      avahi-daemon avahi-utils libnss-mdns
+RUN apk add avahi-daemon avahi-utils libnss-mdns
 
 RUN systemctl enable avahi-daemon
 

--- a/test/test_framework.go
+++ b/test/test_framework.go
@@ -419,7 +419,7 @@ func (s *ServerDefault) Close() {
 	if s.cmd.Process != nil {
 		s.cmd.Process.Signal(syscall.SIGKILL)
 	}
-	exec.Command("docker", "network", "rm", fname)
+	exec.Command("docker", "network", "rm", s.container)
 }
 
 func (s *ServerBase) Command() *Command {

--- a/test/test_framework.go
+++ b/test/test_framework.go
@@ -298,8 +298,12 @@ func newLocalServer(t *T, fname string, opts ...Option) Server {
 		panic("pubKey has not been set")
 	}
 
+	// create the container network
+	exec.Command("docker", "network", "create", "--driver=bridge", fname)
+
 	// run the server
 	cmd := exec.Command("docker", "run", "--name", fname,
+		fmt.Sprintf("--network=%s", fname),
 		fmt.Sprintf("-p=%v:8081", proxyPortnum),
 		fmt.Sprintf("-p=%v:8080", apiPortNum),
 		"-e", "MICRO_AUTH_PRIVATE_KEY="+strings.Trim(string(privKey), "\n"),
@@ -415,6 +419,7 @@ func (s *ServerDefault) Close() {
 	if s.cmd.Process != nil {
 		s.cmd.Process.Signal(syscall.SIGKILL)
 	}
+	exec.Command("docker", "network", "rm", fname)
 }
 
 func (s *ServerBase) Command() *Command {

--- a/test/test_framework.go
+++ b/test/test_framework.go
@@ -299,7 +299,7 @@ func newLocalServer(t *T, fname string, opts ...Option) Server {
 	}
 
 	// create the container network
-	exec.Command("docker", "network", "create", "--driver=bridge", fname)
+	exec.Command("docker", "network", "create", "-d=bridge", fname)
 
 	// run the server
 	cmd := exec.Command("docker", "run", "--name", fname,


### PR DESCRIPTION
I think the integration test should use mdns rather than etcd. Easily done by installing avahi.