### PR TITLE
Incorrectly tagging every result as a failure

### DIFF
--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -345,7 +345,7 @@ func MetricsHandler() server.HandlerWrapper {
 			if err != nil {
 				tags["result"] = "failure"
 			} else {
-				tags["result"] = "failure"
+				tags["result"] = "success"
 			}
 
 			// Instrument the result (if the DefaultClient has been configured):


### PR DESCRIPTION
Copy/paste error meant that both successful and unsuccessful responses were being tagged as failures.