### PR TITLE
self update, write a version file so we don't hammer github

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -278,6 +278,9 @@ func (c *command) Before(ctx *cli.Context) error {
 			// TODO: maybe require relogin or update of the
 			// config...
 			if updated {
+				// considering nil actually continues
+				// we need to os.Exit(0)
+				os.Exit(0)
 				return nil
 			}
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,11 +15,13 @@ import (
 )
 
 var (
+	baseDir = ".micro"
+
 	// lock in single process
 	mtx sync.Mutex
 
 	// file for global micro config
-	file = ".micro/config.json"
+	file = filepath.Join(baseDir, "config.json")
 
 	// full path to file
 	path, _ = filePath()

--- a/internal/config/file.go
+++ b/internal/config/file.go
@@ -1,0 +1,57 @@
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Version represents ./micro/version
+type Version struct {
+	Version string    `json:"version"`
+	Updated time.Time `json:"updated"`
+}
+
+// WriteVersion will write a version update to a file ./micro/version.
+// This indicates the current version and the last time we updated the binary.
+// Its only used where self update is
+func WriteVersion(v string) error {
+	path, err := filePath()
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	b, err := json.Marshal(&Version{
+		Version: v,
+		Updated: time.Now(),
+	})
+	if err != nil {
+		return err
+	}
+	f := filepath.Join(dir, "version")
+	return ioutil.WriteFile(f, b, 0644)
+}
+
+// GetVersion returns the version from .micro/version. If it does not exist
+func GetVersion() (*Version, error) {
+	path, err := filePath()
+	if err != nil {
+		return nil, err
+	}
+	dir := filepath.Dir(path)
+	f := filepath.Join(dir, "version")
+	b, err := ioutil.ReadFile(f)
+	if err != nil {
+		return nil, err
+	}
+	v := new(Version)
+	if err := json.Unmarshal(b, &v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}


### PR DESCRIPTION
Write a .micro/version file which tells us the last time the binary was updated or checked for an update. This is so self update does not hammer the github api. And we simply check once a day for any updates in the case self update is set. Goreleaser has not been updated yet to enable this.