### PR TITLE
Idempotent Helm install for the monitoring stack

### DIFF
--- a/platform/kubernetes/resource/grafana/install.sh
+++ b/platform/kubernetes/resource/grafana/install.sh
@@ -8,7 +8,8 @@ kubectl create namespace ${MONITORING_NAMESPACE}
 helm repo add stable https://kubernetes-charts.storage.googleapis.com
 
 # Install Grafana using Helm:
-helm install grafana stable/grafana \
+helm upgrade grafana stable/grafana \
+    --install \
     --namespace ${MONITORING_NAMESPACE} \
     --set persistence.enabled=true \
     --set persistence.size=1Gi

--- a/platform/kubernetes/resource/monitoring.md
+++ b/platform/kubernetes/resource/monitoring.md
@@ -5,8 +5,8 @@ Monitoring Stack
     - `prometheus/install.sh`
     - `grafana/install.sh`
 2) Log in to Grafana (get the "admin" password from the K8S secret, then portforward)
-    - `kubectl get secret --namespace monitoring grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo`
-    - `kctl port-forward service/grafana 8080:80`
+    - `kubectl -n monitoring get secret grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo`
+    - `kubectl -n monitoring port-forward service/grafana 3000:80`
 3) Configure a Prometheus datasource (server is "http://prometheus-server")
 4) Import some dashboards from Grafana.com:
     - 10000: Cluster Monitoring for Kubernetes
@@ -17,3 +17,5 @@ Monitoring Stack
     - 11466: Cockroach Replicas
     - 11464: Cockroach Storage
 5) Configure a Grafana alert plugin for OpsGenie
+6) You can check out Prometheus itself for more information on its targets:
+    - `kubectl -n monitoring port-forward service/prometheus-server 9090:80`

--- a/platform/kubernetes/resource/prometheus/install.sh
+++ b/platform/kubernetes/resource/prometheus/install.sh
@@ -9,6 +9,7 @@ helm repo add stable https://kubernetes-charts.storage.googleapis.com
 
 # Install Prometheus using Helm:
 helm upgrade prometheus stable/prometheus \
+    --install \
     --namespace ${MONITORING_NAMESPACE} \
     --set alertmanager.enabled=false \
     --set alertmanager.persistentVolume.enabled=false \


### PR DESCRIPTION
This means we can run this on a pre-existing install or a clean slate with the same command.