### PR TITLE
should pass namespace to change password

### DIFF
--- a/client/cli/user/user.go
+++ b/client/cli/user/user.go
@@ -135,12 +135,17 @@ func changePassword(ctx *cli.Context) error {
 			break
 		}
 	}
+	ns, err := currNamespace(ctx)
+	if err != nil {
+		return err
+	}
 
 	accountService := pb.NewAccountsService("auth", client.DefaultClient)
-	_, err := accountService.ChangeSecret(context.DefaultContext, &pb.ChangeSecretRequest{
+	_, err = accountService.ChangeSecret(context.DefaultContext, &pb.ChangeSecretRequest{
 		Id:        email,
 		OldSecret: oldPassword,
 		NewSecret: newPassword,
+		Options:   &pb.Options{Namespace: ns},
 	}, goclient.WithAuthToken())
 	return err
 }
@@ -212,16 +217,24 @@ func getToken(ctx *cli.Context) error {
 
 // get namespace in current env
 func getNamespace(ctx *cli.Context) error {
-	env, err := config.Get("env")
-	if err != nil {
-		return err
-	}
-	namespace, err := config.Get("namespaces", env, "current")
+	namespace, err := currNamespace(ctx)
 	if err != nil {
 		return err
 	}
 	fmt.Println(namespace)
 	return nil
+}
+
+func currNamespace(ctx *cli.Context) (string, error) {
+	env, err := config.Get("env")
+	if err != nil {
+		return "", err
+	}
+	namespace, err := config.Get("namespaces", env, "current")
+	if err != nil {
+		return "", err
+	}
+	return namespace, nil
 }
 
 // set namespace in current env


### PR DESCRIPTION
before 

```
$ micro user set password
Enter current password: 
Enter a new password: 
Verify your password: 
{"Id":"auth.Accounts.ChangeSecret","Code":403,"Detail":"Access denied to namespace","Status":"Forbidden"}
```

after

```
$ micro user set password                       
Enter current password: 
Enter a new password: 
Verify your password: 
$
```