### PR TITLE
pretty print durations with days rather than just hours for micro status

### DIFF
--- a/service/runtime/cli/service.go
+++ b/service/runtime/cli/service.go
@@ -68,7 +68,33 @@ func timeAgo(v string) string {
 	if err != nil {
 		return v
 	}
-	return fmt.Sprintf("%v ago", time.Since(t).Truncate(time.Second))
+
+	return fmt.Sprintf("%v ago", fmtDuration(time.Since(t)))
+}
+
+func fmtDuration(d time.Duration) string {
+	// round to secs
+	d = d.Round(time.Second)
+
+	var resStr string
+	days := d / (time.Hour * 24)
+	if days > 0 {
+		d -= days * time.Hour * 24
+		resStr = fmt.Sprintf("%dd", days)
+	}
+	h := d / time.Hour
+	if len(resStr) > 0 || h > 0 {
+		d -= h * time.Hour
+		resStr = fmt.Sprintf("%s%dh", resStr, h)
+	}
+	m := d / time.Minute
+	if len(resStr) > 0 || m > 0 {
+		d -= m * time.Minute
+		resStr = fmt.Sprintf("%s%dm", resStr, m)
+	}
+	s := d / time.Second
+	resStr = fmt.Sprintf("%s%ds", resStr, s)
+	return resStr
 }
 
 // exists returns whether the given file or directory exists

--- a/service/runtime/cli/service_test.go
+++ b/service/runtime/cli/service_test.go
@@ -1,0 +1,34 @@
+package runtime
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestFmtDuration(t *testing.T) {
+	tcs := []struct {
+		seconds  int64
+		expected string
+	}{
+		{seconds: 15, expected: "15s"},
+		{seconds: 0, expected: "0s"},
+		{seconds: 60, expected: "1m0s"},
+		{seconds: 75, expected: "1m15s"},
+		{seconds: 903, expected: "15m3s"},
+		{seconds: 4532, expected: "1h15m32s"},
+		{seconds: 82808, expected: "23h0m8s"},
+		{seconds: 86400, expected: "1d0h0m0s"},
+		{seconds: 1006400, expected: "11d15h33m20s"},
+		{seconds: 111006360, expected: "11d15h33m0s"},
+	}
+
+	for i, tc := range tcs {
+		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
+			res := fmtDuration(time.Duration(tc.seconds) * time.Second)
+			if res != tc.expected {
+				t.Errorf("Expected %s but got %s", tc.expected, res)
+			}
+		})
+	}
+}

--- a/service/runtime/cli/service_test.go
+++ b/service/runtime/cli/service_test.go
@@ -20,7 +20,7 @@ func TestFmtDuration(t *testing.T) {
 		{seconds: 82808, expected: "23h0m8s"},
 		{seconds: 86400, expected: "1d0h0m0s"},
 		{seconds: 1006400, expected: "11d15h33m20s"},
-		{seconds: 111006360, expected: "11d15h33m0s"},
+		{seconds: 111006360, expected: "1284d19h6m0s"},
 	}
 
 	for i, tc := range tcs {


### PR DESCRIPTION
Fixing the formatting of the updated time in `micro status`

Current
```
$ micro status
NAME		VERSION			SOURCE							STATUS	BUILD	UPDATED		METADATA
alert		latest			github.com/m3o/services/alert				running	n/a	73h1m47s ago	owner=janos, group=micro
billing		customer-id-not-email	github.com/m3o/services/billing				running	n/a	72h44m26s ago	owner=dom, group=micro
...
```

Proposed
```
$ micro status
NAME		VERSION			SOURCE							STATUS	BUILD	UPDATED			METADATA
alert		latest			github.com/m3o/services/alert				running	n/a	3d1h2m12s ago		owner=janos, group=micro
billing		customer-id-not-email	github.com/m3o/services/billing				running	n/a	3d0h44m51s ago		owner=dom, group=micro
...
```