### PR TITLE
Pin micro new template to latest go micro master and micro

### DIFF
--- a/internal/template/module.go
+++ b/internal/template/module.go
@@ -5,6 +5,11 @@ var (
 
 go 1.13
 
+require (
+	github.com/micro/micro/v3 v3.0.0-beta.4.0.20200922151713-de8b56c2b15d
+	github.com/micro/go-micro/v3 v3.0.0-beta.2.0.20200922112322-927d4f8eced6
+)
+
 // This can be removed once etcd becomes go gettable, version 3.4 and 3.5 is not,
 // see https://github.com/etcd-io/etcd/issues/11154 and https://github.com/etcd-io/etcd/issues/11931.
 replace google.golang.org/grpc => google.golang.org/grpc v1.26.0


### PR DESCRIPTION
Currently we have a breaking change in master and I want to release a fix to the 'No entrypoint found bug' (#1381) but that fix won't work due the breaking changes.

We need to remember to remove these.