### PR TITLE
Fixing bug when baseurl gets appended to non com/org/net domains

### DIFF
--- a/service/runtime/cli/service.go
+++ b/service/runtime/cli/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/micro/micro/v3/service/runtime"
 	"github.com/micro/micro/v3/service/runtime/server"
 	"github.com/urfave/cli/v2"
+	"golang.org/x/net/publicsuffix"
 	"google.golang.org/grpc/status"
 )
 
@@ -155,7 +156,9 @@ func sourceExists(source *git.Source) error {
 func appendSourceBase(ctx *cli.Context, workDir, source string) (string, error) {
 	isLocal, _ := git.IsLocal(workDir, source)
 	// @todo add list of supported hosts here or do this check better
-	if !isLocal && !strings.Contains(source, ".com") && !strings.Contains(source, ".org") && !strings.Contains(source, ".net") {
+	domain := strings.Split(source, "/")[0]
+	_, err := publicsuffix.EffectiveTLDPlusOne(domain)
+	if !isLocal && err != nil {
 		env, err := util.GetEnv(ctx)
 		if err != nil {
 			return "", nil


### PR DESCRIPTION
Problem: we detected domains by checking for .com .net .org. This caused .io domains to be appended the baseurl (or micro/services if baseurl was not set), effectively breaking running code from non .com .net .org domains.

This will fail in the following way however: baseurl will not be appended when running a folder that's also a domain.

It's still better than the existing behav of appending baseurl (or default micro/services) when a domain is not .com .org or .net.