### PR TITLE
Fixing tests timing out at 3 minutes even when they return with error quickly

### DIFF
--- a/test/test_framework.go
+++ b/test/test_framework.go
@@ -551,7 +551,6 @@ func TrySuite(t *testing.T, f func(t *T), times int) {
 		case <-done:
 			if tee.failed {
 				if t.Failed() {
-					done <- true
 					return
 				}
 				if len(tee.format) > 0 {
@@ -559,7 +558,6 @@ func TrySuite(t *testing.T, f func(t *T), times int) {
 				} else {
 					t.Fatal(tee.values...)
 				}
-				done <- true
 			}
 			return
 		}

--- a/test/test_framework.go
+++ b/test/test_framework.go
@@ -525,18 +525,7 @@ func TrySuite(t *testing.T, f func(t *T), times int) {
 			tee.attempt++
 			time.Sleep(200 * time.Millisecond)
 		}
-		if tee.failed {
-			if t.Failed() {
-				done <- true
-				return
-			}
-			if len(tee.format) > 0 {
-				t.Fatalf(tee.format, tee.values...)
-			} else {
-				t.Fatal(tee.values...)
-			}
-			done <- true
-		}
+		done <- true
 	}()
 	for {
 		select {
@@ -560,6 +549,18 @@ func TrySuite(t *testing.T, f func(t *T), times int) {
 			t.Fatalf("%v:%v, %v (failed after %v)", fname, line, caller, time.Since(actualStart))
 			return
 		case <-done:
+			if tee.failed {
+				if t.Failed() {
+					done <- true
+					return
+				}
+				if len(tee.format) > 0 {
+					t.Fatalf(tee.format, tee.values...)
+				} else {
+					t.Fatal(tee.values...)
+				}
+				done <- true
+			}
 			return
 		}
 	}


### PR DESCRIPTION
To test this change: have a test that should fail fast and run it. You will see that it takes `3m` to fail with timeout. In my case I killed my local docker registry and run a test that uses it:

Before:
```sh
go clean -testcache && go test --tags=integration -v -run  TestStoreImpl
=== RUN   TestStoreImpl
=== PAUSE TestStoreImpl
=== CONT  TestStoreImpl
--- FAIL: TestStoreImpl (180.00s)
    store_test.go:162: micro run failure, output: EOF
        
    store_test.go:162: micro run failure, output: EOF
        
    store_test.go:162: micro run failure, output: EOF
        
    test_framework.go:535: micro run failure, output: EOF
    store_test.go:148: store_test.go:148, TestStoreImpl (failed after 3m0.000111713s)
FAIL
exit status 1
FAIL	github.com/micro/micro/v3/test	180.005s

```

After:
```sh
$ go clean -testcache && go test --tags=integration -v -run  TestStoreImpl
=== RUN   TestStoreImpl
=== PAUSE TestStoreImpl
=== CONT  TestStoreImpl
--- FAIL: TestStoreImpl (9.48s)
    store_test.go:162: micro run failure, output: EOF
        
    store_test.go:162: micro run failure, output: EOF
        
    store_test.go:162: micro run failure, output: EOF
        
    store_test.go:148: micro run failure, output: EOF
FAIL
exit status 1
FAIL	github.com/micro/micro/v3/test	9.484s
```

By using `watch -n1 docker status` it's clear that the container long exists before the end of the timeout. I suspect this is because `t.Fatal` terminates the function where it's being called, hence `done <- true` never runs.

Edit:

Indeed `Fatal` calls `FailNow` which
`FailNow marks the function as having failed and stops its execution
// by calling runtime.Goexit (which then runs all deferred calls in the`