### PR TITLE
fix etcd cert errors

### DIFF
--- a/cmd/platform/kubernetes/resource/etcd/certs/server.json
+++ b/cmd/platform/kubernetes/resource/etcd/certs/server.json
@@ -3,6 +3,7 @@
     "hosts": [
         "etcd-cluster.default.svc.cluster.local",
         "*.etcd-cluster.default.svc",
+        "*.etcd-cluster-headless.default.svc",
         "etcd-cluster"
     ],
     "key": {


### PR DESCRIPTION
Fixes errors in logs

```
2020-10-08 13:45:23.088337 I | embed: rejected connection from "10.244.0.10:55754" (error "tls: \"10.244.0.10\" does not match any of DNSNames [\"etcd-cluster.default.svc.cluster.local\" \"*.etcd-cluster.default.svc\" \"etcd-cluster\"]", ServerName "etcd-cluster-0.etcd-cluster-headless.default.svc.cluster.local", IPAddresses [], DNSNames ["etcd-cluster.default.svc.cluster.local" "*.etcd-cluster.default.svc" "etcd-cluster"])
```