### PR TITLE
Fix panic when passing in nested objects to dynamic commands

### DIFF
--- a/cmd/dynamic.go
+++ b/cmd/dynamic.go
@@ -386,7 +386,7 @@ loop:
 				}
 
 				if _, ok := result[attr.Name]; !ok {
-					result[attr.Name] = map[string]string{}
+					result[attr.Name] = map[string]interface{}{}
 				} else if _, ok := result[attr.Name].(map[string]string); !ok {
 					return nil, fmt.Errorf("Error parsing request, duplicate key: %v", key)
 				}

--- a/cmd/dynamic_test.go
+++ b/cmd/dynamic_test.go
@@ -155,6 +155,27 @@ func TestDynamicFlagParsing(t *testing.T) {
 				"fs": []interface{}{float64(10.1), float64(20.2)},
 			},
 		},
+		{
+			args: []string{"--user_email=someemail"},
+			values: &goregistry.Value{
+				Values: []*goregistry.Value{
+					{
+						Name: "user",
+						Values: []*goregistry.Value{
+							{
+								Name: "email",
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"user": map[string]interface{}{
+					"email": "someemail",
+				},
+			},
+		},
 	}
 	for _, c := range cases {
 		_, flags, err := splitCmdArgs(c.args)


### PR DESCRIPTION
Fixing

```
        	panic: interface conversion: interface {} is map[string]string, not map[string]interface {}
        
        goroutine 1 [running]:
        github.com/micro/micro/v3/cmd.(*command).Run.func1()
        	/home/crufter/code/src/github.com/micro/micro/cmd/cmd.go:574 +0x136
        panic(0x10b5240, 0xc0005b8db0)
        	/usr/local/go/src/runtime/panic.go:967 +0x15d
        github.com/micro/micro/v3/cmd.flagsToRequest(0xc0005b8d20, 0xc0002c8dc0, 0xc, 0xc00019ac01, 0xc)
        	/home/crufter/code/src/github.com/micro/micro/cmd/dynamic.go:397 +0x824
        github.com/micro/micro/v3/cmd.callService(0xc000593aa0, 0x12a0982, 0x5, 0xc00058e8c0, 0x0, 0x0)
        	/home/crufter/code/src/github.com/micro/micro/cmd/dynamic.go:171 +0x1f6

```
When passing in multi level object to dynamic commands ie `micro users --user_email=email save`
