### PR TITLE
Fix dynamic commands duplicate key bug

### DIFF
--- a/cmd/dynamic.go
+++ b/cmd/dynamic.go
@@ -387,7 +387,7 @@ loop:
 
 				if _, ok := result[attr.Name]; !ok {
 					result[attr.Name] = map[string]interface{}{}
-				} else if _, ok := result[attr.Name].(map[string]string); !ok {
+				} else if _, ok := result[attr.Name].(map[string]interface{}); !ok {
 					return nil, fmt.Errorf("Error parsing request, duplicate key: %v", key)
 				}
 				parsed, err := coerceValue(attr2.Type, value)

--- a/cmd/dynamic_test.go
+++ b/cmd/dynamic_test.go
@@ -176,6 +176,32 @@ func TestDynamicFlagParsing(t *testing.T) {
 				},
 			},
 		},
+		{
+			args: []string{"--user_email=someemail", "--user_name=somename"},
+			values: &goregistry.Value{
+				Values: []*goregistry.Value{
+					{
+						Name: "user",
+						Values: []*goregistry.Value{
+							{
+								Name: "email",
+								Type: "string",
+							},
+							{
+								Name: "name",
+								Type: "string",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"user": map[string]interface{}{
+					"email": "someemail",
+					"name":  "somename",
+				},
+			},
+		},
 	}
 	for _, c := range cases {
 		_, flags, err := splitCmdArgs(c.args)


### PR DESCRIPTION
See test for details. A `duplicate key` error is being thrown when having more than two fields under a top level key (ie. in the case of `user_name` and `user_email`, `user` is the top level key).