### PR TITLE
Dynamic commands: support --flag as true value

### DIFF
--- a/cmd/dynamic.go
+++ b/cmd/dynamic.go
@@ -281,6 +281,9 @@ func flagsToRequest(flags map[string][]string, req *goregistry.Value) (map[strin
 	coerceValue := func(valueType string, value []string) (interface{}, error) {
 		switch valueType {
 		case "bool":
+			if len(strings.TrimSpace(value[0])) == 0 {
+				return true, nil
+			}
 			return strconv.ParseBool(value[0])
 		case "int32":
 			return strconv.Atoi(value[0])

--- a/cmd/dynamic_test.go
+++ b/cmd/dynamic_test.go
@@ -202,6 +202,20 @@ func TestDynamicFlagParsing(t *testing.T) {
 				},
 			},
 		},
+		{
+			args: []string{"--b"},
+			values: &goregistry.Value{
+				Values: []*goregistry.Value{
+					{
+						Name: "b",
+						Type: "bool",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"b": true,
+			},
+		},
 	}
 	for _, c := range cases {
 		_, flags, err := splitCmdArgs(c.args)


### PR DESCRIPTION
Before it was throwing:

```
$ microlive billing apply --all
strconv.ParseBool: parsing "": invalid syntax
```

I think probably -all should be supported too? Or perhaps even just `-all` and `--all` is not?