### PR TITLE
Set reasonable default for resource requirements

### DIFF
--- a/service/runtime/kubernetes/kubernetes.go
+++ b/service/runtime/kubernetes/kubernetes.go
@@ -195,6 +195,15 @@ func (k *kubernetes) create(resource runtime.Resource, opts ...runtime.CreateOpt
 			return err
 		}
 
+		// create some default resource requests
+		if options.Resources == nil {
+			options.Resources = &runtime.Resources{
+				CPU:  200,
+				Mem:  200,
+				Disk: 2000,
+			}
+		}
+
 		// create the deployment
 		if err := k.client.Create(client.NewDeployment(s, options), client.CreateNamespace(options.Namespace)); err != nil {
 			if parseError(err).Reason == "AlreadyExists" {

--- a/service/runtime/kubernetes/kubernetes.go
+++ b/service/runtime/kubernetes/kubernetes.go
@@ -196,7 +196,7 @@ func (k *kubernetes) create(resource runtime.Resource, opts ...runtime.CreateOpt
 		}
 
 		// create some default resource requests
-		if options.Resources == nil {
+		if options.Resources == nil && options.Namespace != "micro" {
 			options.Resources = &runtime.Resources{
 				CPU:  200,
 				Mem:  200,


### PR DESCRIPTION
If unset. Needed so that we can apply resource quotas at the namespace level. 

Default values are 200m CPU, 200M memory, 2GB disk. On M3O dev tier this would equate to being able to run five services for free.

At some point in the future we can expose to end users, but needs some thought about what the API for that would look like