### PR TITLE
profile: use ~/.micro/server for local filestore

### DIFF
--- a/profile/profile.go
+++ b/profile/profile.go
@@ -92,7 +92,7 @@ var Local = &Profile{
 	Name: "local",
 	Setup: func(ctx *cli.Context) error {
 		microAuth.DefaultAuth = jwt.NewAuth()
-		microStore.DefaultStore = file.NewStore(file.WithDir(filepath.Join(user.Dir, "server")))
+		microStore.DefaultStore = file.NewStore(file.WithDir(filepath.Join(user.Dir, "server", "store")))
 		SetupConfigSecretKey(ctx)
 		config.DefaultConfig, _ = storeConfig.NewConfig(microStore.DefaultStore, "")
 		SetupBroker(memBroker.NewBroker())

--- a/profile/profile.go
+++ b/profile/profile.go
@@ -6,6 +6,7 @@ package profile
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/micro/micro/v3/service/auth/jwt"
 	"github.com/micro/micro/v3/service/auth/noop"
@@ -91,7 +92,7 @@ var Local = &Profile{
 	Name: "local",
 	Setup: func(ctx *cli.Context) error {
 		microAuth.DefaultAuth = jwt.NewAuth()
-		microStore.DefaultStore = file.NewStore()
+		microStore.DefaultStore = file.NewStore(file.WithDir(filepath.Join(user.Dir, "server")))
 		SetupConfigSecretKey(ctx)
 		config.DefaultConfig, _ = storeConfig.NewConfig(microStore.DefaultStore, "")
 		SetupBroker(memBroker.NewBroker())


### PR DESCRIPTION
Fixes an issue where the local accounts (persisted in the store) would disappear upon restart. 