### PR TITLE
fix the alignment @ https://micro.mu/reference\#rules

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -460,9 +460,9 @@ Here, the scope `*` is markedly different from the `<public>` scope we have seen
 
 ```sh
 $ micro auth list rules
-ID			    Scope			Access		Resource		Priority
-onlyloggedin	*			    GRANTED		*:*:*			0
-default			<public>		GRANTED		*:*:*			0
+ID            Scope         Access       Resource       Priority
+onlyloggedin  *             GRANTED      *:*:*          0
+default       <public>      GRANTED      *:*:*          0
 ```
 
 Now, let's remove the default rule.


### PR DESCRIPTION
Replaced hard tag(s) with space character(s) instead.
Markdown rule [MD010](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md010)
 
