### PR TITLE
redundant- calling strings.TrimSpace() line 64

### DIFF
--- a/client/cli/auth/login.go
+++ b/client/cli/auth/login.go
@@ -61,7 +61,7 @@ func login(ctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		password = strings.TrimSpace(pw)
+		password = pw
 		fmt.Println()
 	}
 	tok, err := auth.Token(auth.WithCredentials(username, password), auth.WithTokenIssuer(ns))


### PR DESCRIPTION
line [64](https://github.com/micro/micro/blob/master/client/cli/auth/login.go#L64) replaced with `password = pw` cause `pw` is actually the returned value of strings.TrimSpace(...)  
