### PR TITLE
Fix logger redirection

### DIFF
--- a/service/logger/default.go
+++ b/service/logger/default.go
@@ -128,7 +128,7 @@ func (l *defaultLogger) Log(level Level, v ...interface{}) {
 	}
 
 	t := rec.Timestamp.Format("2006-01-02 15:04:05")
-	fmt.Printf("%s %s %v\n", t, metadata, rec.Message)
+	fmt.Fprintf(l.opts.Out, "%s %s %v\n", t, metadata, rec.Message)
 }
 
 func (l *defaultLogger) Logf(level Level, format string, v ...interface{}) {
@@ -167,7 +167,7 @@ func (l *defaultLogger) Logf(level Level, format string, v ...interface{}) {
 	}
 
 	t := rec.Timestamp.Format("2006-01-02 15:04:05")
-	fmt.Printf("%s %s %v\n", t, metadata, rec.Message)
+	fmt.Fprintf(l.opts.Out, "%s %s %v\n", t, metadata, rec.Message)
 }
 
 func (l *defaultLogger) Options() Options {

--- a/service/logger/logger_test.go
+++ b/service/logger/logger_test.go
@@ -15,6 +15,9 @@
 package logger
 
 import (
+	"bufio"
+	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -29,4 +32,14 @@ func TestLogger(t *testing.T) {
 	h2.Warn("warn_msg2")
 
 	l.Fields(map[string]interface{}{"key3": "val4"}).Log(InfoLevel, "test_msg")
+}
+
+func TestLoggerRedirection(t *testing.T) {
+	var b bytes.Buffer
+	wr := bufio.NewWriter(&b)
+	NewLogger(WithOutput(wr)).Logf(InfoLevel, "test message")
+	wr.Flush()
+	if !strings.Contains(b.String(), "level=info test message") {
+		t.Fatalf("Redirection failed, received '%s'", b.String())
+	}
 }


### PR DESCRIPTION
Was always printing to stdout. Now respects the `Out` option