### PR TITLE
fix random selector to choose from full range of nodes

### DIFF
--- a/internal/selector/random/random.go
+++ b/internal/selector/random/random.go
@@ -36,7 +36,7 @@ func (r *random) Select(routes []string, opts ...selector.SelectOption) (selecto
 		}
 
 		// select a random route from the slice
-		return routes[rand.Intn(len(routes)-1)]
+		return routes[rand.Intn(len(routes))]
 	}, nil
 }
 


### PR DESCRIPTION
`rand.Intn()` returns an int in the range [0,n) which is 0->n exclusive i.e. 0..n-1. This means the current logic actually leaves off the final node. 