### PR TITLE
Streaming NATS reconnect

### DIFF
--- a/plugin/nats/broker/nats.go
+++ b/plugin/nats/broker/nats.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/micro/micro/v3/service/registry/mdns"
 	"github.com/micro/micro/v3/service/broker"
 	"github.com/micro/micro/v3/service/logger"
+	"github.com/micro/micro/v3/service/registry/mdns"
 	nats "github.com/nats-io/nats.go"
 )
 


### PR DESCRIPTION
Reconnect to streaming NATS cluster if the pods die. Makes use of the stan `ConnectionLostHandler` to reconnect in case of bad connection. We don't need the same for the NATS broker since that client library seems to manage to reconnect without issue.