### PR TITLE
Turn off retries by default

### DIFF
--- a/service/client/client.go
+++ b/service/client/client.go
@@ -115,7 +115,7 @@ var (
 	// DefaultBackoff is the default backoff function for retries
 	DefaultBackoff = exponentialBackoff
 	// DefaultRetry is the default check-for-retry function for retries
-	DefaultRetry = RetryOnError
+	DefaultRetry = RetryNever
 	// DefaultRetries is the default number of times a request is tried
 	DefaultRetries = 1
 	// DefaultRequestTimeout is the default request timeout

--- a/service/client/mucp/mucp_test.go
+++ b/service/client/mucp/mucp_test.go
@@ -104,6 +104,7 @@ func TestCallRetry(t *testing.T) {
 	c := NewClient(
 		client.Router(r),
 		client.WrapCall(wrap),
+		client.Retry(client.RetryOnError),
 	)
 
 	req := c.NewRequest(service, endpoint, nil)

--- a/service/client/retry.go
+++ b/service/client/retry.go
@@ -49,3 +49,8 @@ func RetryOnError(ctx context.Context, req Request, retryCount int, err error) (
 		return false, nil
 	}
 }
+
+// RetryNever never retries a request
+func RetryNever(ctx context.Context, req Request, retryCount int, err error) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
Retries on endpoint that don't support idempotency can lead to undesired/unpredictable behaviour - duplicate payments, emails, etc. Users should explicitly have to turn on retries as an option.

This is a BREAKING change and needs a minor version bump to 3.1.0