### PR TITLE
Update README.md

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -506,7 +506,7 @@ func main() {
 	srv.Init()
 
 	// read config value
-	val, _ := config.Get("key", "subkey")
+	val, _ := config.Get("key.subkey")
 	fmt.Println("Value of key.subkey: ", val.String(""))
 }
 ```


### PR DESCRIPTION
In **Config** part, the code line:  
> val, _ := config.Get("key", "subkey")

should be:  
> val, _ := config.Get("key.subkey")
