### PR TITLE
Remove CPU limits for deployments

### DIFF
--- a/internal/kubernetes/client/client.go
+++ b/internal/kubernetes/client/client.go
@@ -494,14 +494,26 @@ func NewResourceQuota(resourceQuota *runtime.ResourceQuota) *ResourceQuota {
 		},
 	}
 	if resourceQuota.Limits != nil {
-		rq.Spec.Hard.LimitsCPU = fmt.Sprintf("%dm", resourceQuota.Limits.CPU)
-		rq.Spec.Hard.LimitsEphemeralStorage = fmt.Sprintf("%dMi", resourceQuota.Limits.Disk)
-		rq.Spec.Hard.LimitsMemory = fmt.Sprintf("%dMi", resourceQuota.Limits.Mem)
+		if resourceQuota.Limits.CPU > 0 {
+			rq.Spec.Hard.LimitsCPU = fmt.Sprintf("%dm", resourceQuota.Limits.CPU)
+		}
+		if resourceQuota.Limits.Disk > 0 {
+			rq.Spec.Hard.LimitsEphemeralStorage = fmt.Sprintf("%dMi", resourceQuota.Limits.Disk)
+		}
+		if resourceQuota.Limits.Mem > 0 {
+			rq.Spec.Hard.LimitsMemory = fmt.Sprintf("%dMi", resourceQuota.Limits.Mem)
+		}
 	}
 	if resourceQuota.Requests != nil {
-		rq.Spec.Hard.RequestsCPU = fmt.Sprintf("%dm", resourceQuota.Requests.CPU)
-		rq.Spec.Hard.RequestsEphemeralStorage = fmt.Sprintf("%dMi", resourceQuota.Requests.Disk)
-		rq.Spec.Hard.RequestsMemory = fmt.Sprintf("%dMi", resourceQuota.Requests.Mem)
+		if resourceQuota.Requests.CPU > 0 {
+			rq.Spec.Hard.RequestsCPU = fmt.Sprintf("%dm", resourceQuota.Requests.CPU)
+		}
+		if resourceQuota.Requests.Disk > 0 {
+			rq.Spec.Hard.RequestsEphemeralStorage = fmt.Sprintf("%dMi", resourceQuota.Requests.Disk)
+		}
+		if resourceQuota.Requests.Mem > 0 {
+			rq.Spec.Hard.RequestsMemory = fmt.Sprintf("%dMi", resourceQuota.Requests.Mem)
+		}
 	}
 
 	return rq

--- a/service/runtime/kubernetes/kubernetes.go
+++ b/service/runtime/kubernetes/kubernetes.go
@@ -28,9 +28,9 @@ import (
 
 var (
 	DefaultServiceResources = &runtime.Resources{
-		CPU:  200,
 		Mem:  200,
 		Disk: 2000,
+		// explicitly not doing CPU here
 	}
 
 	DefaultImage = "micro/cells:v3"

--- a/service/runtime/resource.go
+++ b/service/runtime/resource.go
@@ -26,12 +26,10 @@ const (
 
 var (
 	defaultRequests = &Resources{
-		CPU:  2000, // 2GB
 		Mem:  2000, // 2GB
 		Disk: 5000, // 5GB
 	}
 	defaultLimits = &Resources{
-		CPU:  4000,  // 4GB
 		Mem:  4000,  // 4GB
 		Disk: 10000, // 10GB
 	}

--- a/service/runtime/resource_test.go
+++ b/service/runtime/resource_test.go
@@ -84,10 +84,10 @@ func TestResources(t *testing.T) {
 	assert.NotNil(t, networkPolicy)
 	assert.Equal(t, TypeResourceQuota, resourceQuota.Type())
 	assert.Equal(t, "test.userquota", resourceQuota.String())
-	assert.Equal(t, 2000, resourceQuota.Requests.CPU)
+	assert.Equal(t, 0, resourceQuota.Requests.CPU)
 	assert.Equal(t, 2000, resourceQuota.Requests.Mem)
 	assert.Equal(t, 5000, resourceQuota.Requests.Disk)
-	assert.Equal(t, 4000, resourceQuota.Limits.CPU)
+	assert.Equal(t, 0, resourceQuota.Limits.CPU)
 	assert.Equal(t, 4000, resourceQuota.Limits.Mem)
 	assert.Equal(t, 10000, resourceQuota.Limits.Disk)
 


### PR DESCRIPTION
As it's making it difficult to pack services in to the nodes efficiently