### PR TITLE
Handle OpenAPI object arrays properly

### DIFF
--- a/internal/openapi/converter/message.go
+++ b/internal/openapi/converter/message.go
@@ -188,7 +188,18 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 
 		// Maps, arrays, and objects are structured in different ways:
 		switch {
-
+		// Arrays:
+		case desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_REPEATED:
+			// componentSchema.Items = openapi3.NewSchemaRef("", recursedComponentSchema)
+			// componentSchema.AdditionalProperties = openapi3.NewSchemaRef("", recursedComponentSchema)
+			componentSchema.Items = &openapi3.SchemaRef{
+				Value: &openapi3.Schema{
+					Type:       openAPITypeObject,
+					Properties: recursedComponentSchema.Properties,
+				},
+			}
+			//componentSchema.Properties =
+			componentSchema.Type = openAPITypeArray
 		// Maps:
 		case recordType.Options.GetMapEntry():
 			logger.Tracef("Found a map (%s.%s)", *msg.Name, recordType.GetName())

--- a/internal/openapi/converter/message.go
+++ b/internal/openapi/converter/message.go
@@ -190,15 +190,12 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		switch {
 		// Arrays:
 		case desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_REPEATED:
-			// componentSchema.Items = openapi3.NewSchemaRef("", recursedComponentSchema)
-			// componentSchema.AdditionalProperties = openapi3.NewSchemaRef("", recursedComponentSchema)
 			componentSchema.Items = &openapi3.SchemaRef{
 				Value: &openapi3.Schema{
 					Type:       openAPITypeObject,
 					Properties: recursedComponentSchema.Properties,
 				},
 			}
-			//componentSchema.Properties =
 			componentSchema.Type = openAPITypeArray
 		// Maps:
 		case recordType.Options.GetMapEntry():


### PR DESCRIPTION
Without this fix, object arrays appear as objects, for example list users response type renders as:

```js
{
  "users": {
    "email": "string",
    "firstName": "string",
    "id": "string",
    "lastName": "string"
  }
}
```

This fixes so it becomes
```js
{
  "users": [{
    "email": "string",
    "firstName": "string",
    "id": "string",
    "lastName": "string"
  }]
}
```