### PR TITLE
Fix empty request error

### DIFF
--- a/internal/api/handler/rpc/stream.go
+++ b/internal/api/handler/rpc/stream.go
@@ -78,6 +78,10 @@ func serveStream(ctx context.Context, w http.ResponseWriter, r *http.Request, se
 		}
 		return
 	}
+	if len(payload) == 0 {
+		// make it valid json
+		payload = []byte("{}")
+	}
 
 	var request interface{}
 	if !bytes.Equal(payload, []byte(`{}`)) {


### PR DESCRIPTION
When no request is passed in curl and downstream is a stream we see an error in logs but 200 returned.

```
2021-03-23 17:59:07  file=rpc/stream.go:127 level=error service=api rpc error: code = Internal desc = grpc: error while marshaling: json: error calling MarshalJSON for type *json.RawMessage: unexpected end of JSON input
::1 - - [23/Mar/2021:17:59:07 +0000] "GET /v1/helloworld/call HTTP/1.1" 200 0 "" "curl/7.64.1"
```

Make sure we pass *something* if request payload is empty