### PR TITLE
Fix #1741: Fail to "make proto" on the project which was create by "micro new". 

### DIFF
--- a/internal/template/proto.go
+++ b/internal/template/proto.go
@@ -5,7 +5,7 @@ var (
 
 package {{dehyphen .Alias}};
 
-option go_package = "proto;{{dehyphen .Alias}}";
+option go_package = "./proto;{{dehyphen .Alias}}";
 
 service {{title .Alias}} {
 	rpc Call(Request) returns (Response) {}


### PR DESCRIPTION
closes #1741 

Modify the template `internal/template/proto.go`, `proto` ==> `./proto`.
This can fix error `The import path must contain at least one forward slash ('/') character`
