### PR TITLE
Correct prompt for `micro login` in doc.

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -86,8 +86,8 @@ Before interacting with the `micro server`, we need to log in with the id 'admin
 
 ```sh
 $ micro login
-Enter email address: admin
-Enter Password:
+Enter username: admin
+Enter password:
 Successfully logged in.
 ```
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -421,8 +421,8 @@ To login to a server simply so the following
 
 ```
 $ micro login
-Enter email address: admin
-Enter Password: 
+Enter username: admin
+Enter password: 
 Successfully logged in.
 ```
 


### PR DESCRIPTION
The prompt for login in all docs was as the following.
```bash
$ micro login
Enter email address: admin
Enter Password: 
Successfully logged in.
```

Actually `email address` should be `username`

```bash
$ micro login
Enter username: admin
Enter password: 
Successfully logged in.
```