### PR TITLE
WIP: Use the local profile by default

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -86,8 +86,9 @@ var (
 		},
 		&cli.StringFlag{
 			Name:    "profile",
-			Usage:   "Set the micro server profile: e.g. local or kubernetes",
+			Usage:   "Set the micro server profile: e.g. local, kubernetes, client, service",
 			EnvVars: []string{"MICRO_PROFILE"},
+			Value:   "local",
 		},
 		&cli.StringFlag{
 			Name:    "namespace",
@@ -430,7 +431,7 @@ func (c *command) Before(ctx *cli.Context) error {
 	if len(ctx.String("auth_public_key")) > 0 || len(ctx.String("auth_private_key")) > 0 {
 		authOpts = append(authOpts, auth.PublicKey(ctx.String("auth_public_key")))
 		authOpts = append(authOpts, auth.PrivateKey(ctx.String("auth_private_key")))
-	} else if ctx.Args().First() == "server" || ctx.Args().First() == "service" {
+	} else if ctx.Args().First() == "server" || ctx.Args().First() == "service" || prof == "local" {
 		privKey, pubKey, err := user.GetJWTCerts()
 		if err != nil {
 			logger.Fatalf("Error getting keys: %v", err)

--- a/service/runtime/kubernetes/client/client_test.go
+++ b/service/runtime/kubernetes/client/client_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/micro/micro/v3/service/runtime"
 
-	"github.com/micro/micro/v3/test/fakes"
 	"github.com/micro/micro/v3/service/runtime/kubernetes/api"
+	"github.com/micro/micro/v3/test/fakes"
 
 	. "github.com/onsi/gomega"
 )

--- a/service/runtime/manager/manager.go
+++ b/service/runtime/manager/manager.go
@@ -15,9 +15,9 @@ import (
 	"github.com/micro/micro/v3/service/client"
 	"github.com/micro/micro/v3/service/logger"
 	"github.com/micro/micro/v3/service/runtime"
+	kclient "github.com/micro/micro/v3/service/runtime/kubernetes/client"
 	"github.com/micro/micro/v3/service/runtime/source/git"
 	"github.com/micro/micro/v3/service/store"
-	kclient "github.com/micro/micro/v3/service/runtime/kubernetes/client"
 	"github.com/micro/micro/v3/util/namespace"
 )
 

--- a/service/server/grpc/util.go
+++ b/service/server/grpc/util.go
@@ -18,10 +18,10 @@ package grpc
 
 import (
 	"context"
-	"io"
 	"fmt"
-	"strings"
+	"io"
 	"os"
+	"strings"
 	"sync"
 
 	"google.golang.org/grpc/codes"


### PR DESCRIPTION
By enabling the local profile by default we are able to run services using "go run" on a local machine. This will talk directly to infra through the interfaces rather than requiring the micro server. In the event other profiles are used, this may not function as expected. We may need to rewrite how dependency setup occurs to improve on this.

When using the "local" profile, services will share a public/private keypair.

Note: Current issues are related to the CLI not working with the local profile. This potentially highlights that we need to split cmd loading for the cli and service.