### PR TITLE
fix up broker subscription retry

### DIFF
--- a/service/broker/client/client.go
+++ b/service/broker/client/client.go
@@ -104,7 +104,7 @@ func (b *serviceBroker) Subscribe(topic string, handler broker.Handler, opts ...
 					stream, err := b.Client.Subscribe(context.DefaultContext, &pb.SubscribeRequest{
 						Topic: topic,
 						Queue: options.Queue,
-					}, client.WithAddress(b.Addrs...), client.WithRequestTimeout(time.Hour))
+					}, client.WithAuthToken(), client.WithAddress(b.Addrs...), client.WithRequestTimeout(time.Hour))
 					if err != nil {
 						if logger.V(logger.DebugLevel, logger.DefaultLogger) {
 							logger.Debugf("Failed to resubscribe to topic %s: %v", topic, err)

--- a/service/broker/client/subscriber.go
+++ b/service/broker/client/subscriber.go
@@ -62,8 +62,8 @@ func (s *serviceSub) run() error {
 		// TODO: do not fail silently
 		msg, err := s.stream.Recv()
 		if err != nil {
-			if logger.V(logger.DebugLevel, logger.DefaultLogger) {
-				logger.Debugf("Streaming error for subcription to topic %s: %v", s.Topic(), err)
+			if logger.V(logger.ErrorLevel, logger.DefaultLogger) {
+				logger.Errorf("Streaming error for subscription to topic %s: %v", s.Topic(), err)
 			}
 
 			// close the exit channel


### PR DESCRIPTION
Currently retry pf failed broker subscription results in hard loop of failure because it's missing the WithAuthToken option