### PR TITLE
add streaming response to openapi spec

### DIFF
--- a/cmd/protoc-gen-openapi/converter/service.go
+++ b/cmd/protoc-gen-openapi/converter/service.go
@@ -110,6 +110,15 @@ func (c *Converter) convertServiceType(file *descriptor.FileDescriptorProto, cur
 			},
 		}
 
+		// check if it's a streaming response
+		if method.GetServerStreaming() {
+			pathItem.Post.Responses["stream"] = &openapi3.ResponseRef{
+				Ref: responseBodySchemaPath(responseBodyName),
+			}
+		}
+
+		// TODO: check for method.GetClientStreaming()
+
 		// Generate a description from src comments (if available)
 		if src := c.sourceInfo.GetService(svc); src != nil {
 			pathItem.Description = formatDescription(src)


### PR DESCRIPTION
Currently there's no way to specify streams in the openapi

The output is as follows

```
      "post": {
        "requestBody": {
          "$ref": "#/components/requestBodies/HelloStreamRequest"
        },
        "responses": {
          "200": {
            "$ref": "#/components/responses/HelloStreamResponse"
          },
          "default": {
            "$ref": "#/components/responses/MicroAPIError"
          }
        },
```

This PR augments it to return

```
      "post": {
        "requestBody": {
          "$ref": "#/components/requestBodies/HelloStreamRequest"
        },
        "responses": {
          "200": {
            "$ref": "#/components/responses/HelloStreamResponse"
          },
          "default": {
            "$ref": "#/components/responses/MicroAPIError"
          },
          "stream": {
            "$ref": "#/components/responses/HelloStreamResponse"
          }
        },
```

We do not yet implement client side streaming