### PR TITLE
[WIP] Add ARM64 compatibility to containers

### DIFF
--- a/.github/workflows/cells.yml
+++ b/.github/workflows/cells.yml
@@ -13,6 +13,12 @@ jobs:
     - name: Clone repo
       uses: actions/checkout@v2
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
     - name: Build cells
       run: cd service/runtime/cells; bash build.sh
       env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,14 +15,37 @@ jobs:
     - name: Clone repo
       uses: actions/checkout@v2
 
-    - name: Fetch tags
-      run: git fetch --prune --unshallow
+    - name: Unique tag
+      id: unique_tag
+      run: echo "::set-output name=tag::$(date +%Y%m%d%H%M%S)$(git rev-parse --short HEAD)"
+      shell: bash
 
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v3
       with:
-        name: micro/micro
+        images: micro/micro
+        flavor: latest=true
+        tags: ${{ steps.unique_tag.outputs.tag }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        tag_names: true
-        snapshot: true
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        platforms: linux/amd64,linux/arm64
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,9 @@ jobs:
     - name: Clone repo
       uses: actions/checkout@v2
 
+    - name: Fetch tags
+      run: git fetch --prune --unshallow
+
     - name: Unique tag
       id: unique_tag
       run: echo "::set-output name=tag::$(date +%Y%m%d%H%M%S)$(git rev-parse --short HEAD)"

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,7 @@ build:
 	go build -a -installsuffix cgo -ldflags "-s -w ${LDFLAGS}" -o $(NAME)
 
 docker:
-	docker build -t $(IMAGE_NAME):$(IMAGE_TAG) .
-	docker tag $(IMAGE_NAME):$(IMAGE_TAG) $(IMAGE_NAME):latest
-	docker push $(IMAGE_NAME):$(IMAGE_TAG)
-	docker push $(IMAGE_NAME):latest
+	docker buildx build --platform linux/amd64 --platform linux/arm64 --tag $(IMAGE_NAME):$(IMAGE_TAG) --tag $(IMAGE_NAME):latest --push .
 
 .PHONY: proto
 proto:

--- a/service/runtime/cells/build.sh
+++ b/service/runtime/cells/build.sh
@@ -27,8 +27,7 @@ ls | while read dir; do
     continue
   fi
 
-  docker build -t $TAG .
-  docker push $TAG
+  docker buildx build --platform linux/amd64 --platform linux/arm64 --tag $TAG --push .
 
   popd &>/dev/null
 done


### PR DESCRIPTION
By using Docker's `docker buildx` command we are able to build Docker images for multiple platforms at the same time. It also supports multiple tags and pushing. We use this to push all the platform specific Docker images to the Docker registry with a single manifest.

## Todo

- [x] Add ARM64 compatibility to `micro/micro` Docker image
- [x] Add ARM64 compatibility to `micro/cells` Docker image
- [x] Ensure CI builds multiarch `micro/micro` Docker image
- [x] Ensure CI builds multiarch `micro/cells` Docker image
- [x] Fix "panic: Malformed version" error

Closes #1825