### PR TITLE
Fix an inaccuracy in the log command docs

### DIFF
--- a/cmd/cli/run/cli.go
+++ b/cmd/cli/run/cli.go
@@ -111,7 +111,7 @@ func init() {
 				&cli.BoolFlag{
 					Name:    "follow",
 					Aliases: []string{"f"},
-					Usage:   "Set to stream logs continuously (default: true)",
+					Usage:   "Set to stream logs continuously",
 				},
 				&cli.StringFlag{
 					Name:  "since",


### PR DESCRIPTION
The "cli" package automatically generates the (default: x) message for the
flag type.
Current implementation leads to --follow option documentation
stuttering by `(default: true) (default: false)`. This is doubly wrong
because the option is off by default and first message can lead to
some sort of misunderstanding.

<img width="967" alt="1" src="https://user-images.githubusercontent.com/4927633/131981249-64814d1a-54d9-419c-8457-6bcde33b8eae.png">
