### PR TITLE
multipart form data support

### DIFF
--- a/service/client/client.go
+++ b/service/client/client.go
@@ -119,7 +119,7 @@ var (
 	// DefaultRetries is the default number of times a request is tried
 	DefaultRetries = 1
 	// DefaultRequestTimeout is the default request timeout
-	DefaultRequestTimeout = time.Second * 5
+	DefaultRequestTimeout = time.Second * 10
 	// DefaultPoolSize sets the connection pool size
 	DefaultPoolSize = 100
 	// DefaultPoolTTL sets the connection pool ttl

--- a/service/client/grpc/codec.go
+++ b/service/client/grpc/codec.go
@@ -55,6 +55,7 @@ var (
 		"application/grpc+json":    jsonCodec{},
 		"application/grpc+proto":   protoCodec{},
 		"application/grpc+bytes":   bytesCodec{},
+		"multipart/form-data":      jsonCodec{},
 	}
 )
 

--- a/service/server/grpc/codec.go
+++ b/service/server/grpc/codec.go
@@ -52,6 +52,7 @@ var (
 		"application/grpc+json":    jsonCodec{},
 		"application/grpc+proto":   protoCodec{},
 		"application/grpc+bytes":   bytesCodec{},
+		"multipart/form-data":      jsonCodec{},
 	}
 )
 

--- a/service/server/grpc/grpc.go
+++ b/service/server/grpc/grpc.go
@@ -20,6 +20,8 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -385,9 +387,62 @@ func (g *grpcServer) processRequest(stream grpc.ServerStream, service *service, 
 			argIsValue = true
 		}
 
-		// Unmarshal request
-		if err := stream.RecvMsg(argv.Interface()); err != nil {
+		var raw json.RawMessage
+
+		// Unmarshal request in to a generic map[string]interface{}
+		if err := stream.RecvMsg(&raw); err != nil {
+			logger.Errorf("Error receiving %s", err)
 			return err
+		}
+
+		// first try parsing it as normal
+		if err := json.Unmarshal(raw, argv.Interface()); err != nil {
+			// let's try parsing it manually
+			var gen map[string]interface{}
+			if err := json.Unmarshal(raw, &gen); err != nil {
+				return err
+			}
+			for i := 0; i < argv.Elem().NumField(); i++ {
+				field := argv.Elem().Field(i)
+				if !field.CanSet() {
+					continue
+				}
+				fieldName := strings.Split(argv.Elem().Type().Field(i).Tag.Get("json"), ",")[0]
+				kindVal := argv.Elem().Field(i).Kind()
+				if len(fieldName) == 0 {
+					continue
+				}
+				if _, ok := gen[fieldName]; !ok {
+					continue
+				}
+				if s, ok := gen[fieldName].(string); ok {
+					// be more permissive by trying to convert string in to the correct type
+					switch kindVal {
+					case reflect.Bool:
+						b, err := strconv.ParseBool(s)
+						if err != nil {
+							return err
+						}
+						field.SetBool(b)
+					case reflect.Int64, reflect.Int32, reflect.Int:
+						in, err := strconv.ParseInt(s, 10, 64)
+						if err != nil {
+							return err
+						}
+						field.SetInt(in)
+					case reflect.Slice: // byte slice
+						b, err := base64.StdEncoding.DecodeString(s)
+						if err != nil {
+							return err
+						}
+						field.SetBytes(b)
+					default:
+						field.Set(reflect.ValueOf(gen[fieldName]))
+					}
+				} else {
+					field.Set(reflect.ValueOf(gen[fieldName]))
+				}
+			}
 		}
 
 		if argIsValue {

--- a/service/server/grpc/grpc.go
+++ b/service/server/grpc/grpc.go
@@ -387,60 +387,65 @@ func (g *grpcServer) processRequest(stream grpc.ServerStream, service *service, 
 			argIsValue = true
 		}
 
-		var raw json.RawMessage
-
-		// Unmarshal request in to a generic map[string]interface{}
-		if err := stream.RecvMsg(&raw); err != nil {
-			logger.Errorf("Error receiving %s", err)
-			return err
-		}
-
-		// first try parsing it as normal
-		if err := json.Unmarshal(raw, argv.Interface()); err != nil {
-			// let's try parsing it manually
-			var gen map[string]interface{}
-			if err := json.Unmarshal(raw, &gen); err != nil {
+		if defaultGRPCCodecs[ct].Name() != "json" {
+			if err := stream.RecvMsg(argv.Interface()); err != nil {
 				return err
 			}
-			for i := 0; i < argv.Elem().NumField(); i++ {
-				field := argv.Elem().Field(i)
-				if !field.CanSet() {
-					continue
+		} else {
+			var raw json.RawMessage
+
+			// Unmarshal request in to a generic map[string]interface{}
+			if err := stream.RecvMsg(&raw); err != nil {
+				return err
+			}
+
+			// first try parsing it as normal
+			if err := json.Unmarshal(raw, argv.Interface()); err != nil {
+				// let's try parsing it manually
+				var gen map[string]interface{}
+				if err := json.Unmarshal(raw, &gen); err != nil {
+					return err
 				}
-				fieldName := strings.Split(argv.Elem().Type().Field(i).Tag.Get("json"), ",")[0]
-				kindVal := argv.Elem().Field(i).Kind()
-				if len(fieldName) == 0 {
-					continue
-				}
-				if _, ok := gen[fieldName]; !ok {
-					continue
-				}
-				if s, ok := gen[fieldName].(string); ok {
-					// be more permissive by trying to convert string in to the correct type
-					switch kindVal {
-					case reflect.Bool:
-						b, err := strconv.ParseBool(s)
-						if err != nil {
-							return err
+				for i := 0; i < argv.Elem().NumField(); i++ {
+					field := argv.Elem().Field(i)
+					if !field.CanSet() {
+						continue
+					}
+					fieldName := strings.Split(argv.Elem().Type().Field(i).Tag.Get("json"), ",")[0]
+					kindVal := argv.Elem().Field(i).Kind()
+					if len(fieldName) == 0 {
+						continue
+					}
+					if _, ok := gen[fieldName]; !ok {
+						continue
+					}
+					if s, ok := gen[fieldName].(string); ok {
+						// be more permissive by trying to convert string in to the correct type
+						switch kindVal {
+						case reflect.Bool:
+							b, err := strconv.ParseBool(s)
+							if err != nil {
+								return err
+							}
+							field.SetBool(b)
+						case reflect.Int64, reflect.Int32, reflect.Int:
+							in, err := strconv.ParseInt(s, 10, 64)
+							if err != nil {
+								return err
+							}
+							field.SetInt(in)
+						case reflect.Slice: // byte slice
+							b, err := base64.StdEncoding.DecodeString(s)
+							if err != nil {
+								return err
+							}
+							field.SetBytes(b)
+						default:
+							field.Set(reflect.ValueOf(gen[fieldName]))
 						}
-						field.SetBool(b)
-					case reflect.Int64, reflect.Int32, reflect.Int:
-						in, err := strconv.ParseInt(s, 10, 64)
-						if err != nil {
-							return err
-						}
-						field.SetInt(in)
-					case reflect.Slice: // byte slice
-						b, err := base64.StdEncoding.DecodeString(s)
-						if err != nil {
-							return err
-						}
-						field.SetBytes(b)
-					default:
+					} else {
 						field.Set(reflect.ValueOf(gen[fieldName]))
 					}
-				} else {
-					field.Set(reflect.ValueOf(gen[fieldName]))
 				}
 			}
 		}


### PR DESCRIPTION
Adding support for `multipart/form-data` calls to the API. 

Allows us to then do something like this

`curl api.m3o.com/foo/bar -F hello=world -F file=@/foo.jpg` 

Gets translated and sent to a service with a request that looks like
```
message BarRequest {
  string hello = 1;
  bytes file = 2;
}
```

This works in two steps. 

First we now support content type of `mutipart/form-data` and take values from that and map to a json. Form fields are strings (regardless of whether they should be a bool, int, etc). This gets sent over the wire. 

When it hits the target service we check the content type of the incoming message, if it's a json codec we will try to parse the message in the normal way and if we fail we will try to parse the json again in a more permissive style - converting strings in to the correct target type (bool, int, etc).