### PR TITLE
Return error json to streaming clients 

### DIFF
--- a/service/api/handler/rpc/stream.go
+++ b/service/api/handler/rpc/stream.go
@@ -220,7 +220,7 @@ func (s *stream) processWSReadsAndWrites() {
 
 func (s *stream) clientToServerLoop(cancel context.CancelFunc, wg *sync.WaitGroup, stopCtx context.Context) {
 	defer func() {
-		s.conn.Close()
+		s.stream.Close()
 		cancel()
 		wg.Done()
 	}()
@@ -282,6 +282,9 @@ func (s *stream) rspToBufLoop(cancel context.CancelFunc, wg *sync.WaitGroup, sto
 				// clean exit
 				return
 			}
+			// write error then close the connection
+			b, _ := json.Marshal(err)
+			s.conn.WriteMessage(s.messageType, b)
 			s.conn.WriteMessage(websocket.CloseAbnormalClosure, []byte{})
 			return
 		}
@@ -297,9 +300,10 @@ func (s *stream) rspToBufLoop(cancel context.CancelFunc, wg *sync.WaitGroup, sto
 
 func (s *stream) bufToClientLoop(cancel context.CancelFunc, wg *sync.WaitGroup, stopCtx context.Context, msgs chan []byte) {
 	defer func() {
+		s.conn.Close()
 		cancel()
 		wg.Done()
-		s.stream.Close()
+
 	}()
 	ticker := time.NewTicker(pingPeriod)
 	defer ticker.Stop()


### PR DESCRIPTION
Per https://github.com/m3o/m3o/issues/80 we're not returning errors on websocket calls. Marhsal the json and then close the conn