### PR TITLE
fix: micro update .

### DIFF
--- a/client/cli/run/service.go
+++ b/client/cli/run/service.go
@@ -518,10 +518,6 @@ func updateService(ctx *cli.Context) error {
 
 	name := ctx.String("name")
 
-	if v := ctx.Args().Get(0); len(v) > 0 {
-		name = v
-	}
-
 	if len(name) == 0 {
 		name = source.RuntimeName()
 	}


### PR DESCRIPTION
fix command `micro update .`:

currently `micro update .` not working and print this message in a shell: 
```
$micro update .                                                                                                                                
not found
```
`micro logs -f runtime` output:
```
file=handler/handler.go:475 level=info service=runtime Updating service . version latest source source://.:latest
```
after investigation, I found that these lines change the name to `.`, while the name must be the local folder name
 