### PR TITLE
Ensure the new template binary can be build locally

### DIFF
--- a/client/cli/new/new.go
+++ b/client/cli/new/new.go
@@ -25,7 +25,8 @@ func protoComments(goDir, alias string) []string {
 		"visit https://github.com/protocolbuffers/protobuf/releases",
 		"\ncompile the proto file " + alias + ".proto:\n",
 		"cd " + alias,
-		"make init\n",
+		"make init",
+		"go mod vendor",
 		"make proto\n",
 	}
 }

--- a/client/cli/new/template/module.go
+++ b/client/cli/new/template/module.go
@@ -6,11 +6,13 @@ var (
 go 1.15
 
 require (
-	github.com/micro/micro/v3 v3.0.0
+	github.com/golang/protobuf latest
+	github.com/micro/micro/v3 latest
+	google.golang.org/protobuf latest
 )
 
 // This can be removed once etcd becomes go gettable, version 3.4 and 3.5 is not,
 // see https://github.com/etcd-io/etcd/issues/11154 and https://github.com/etcd-io/etcd/issues/11931.
-replace google.golang.org/grpc => google.golang.org/grpc v1.26.0
+replace google.golang.org/grpc => google.golang.org/grpc v1.27.1
 `
 )


### PR DESCRIPTION
- grpc {1.26.0,1.27.1} because grpc.ClientConnInterface was undefined