### PR TITLE
change error response to using lowercase for consistency response with success response based on standard JSON REST API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/micro/micro/v3
+module github.com/agus7fauzi/micro/v3
 
 go 1.16
 

--- a/service/errors/errors.go
+++ b/service/errors/errors.go
@@ -23,10 +23,10 @@ import (
 )
 
 type Error struct {
-	Id     string
-	Code   int32
-	Detail string
-	Status string
+	id     string
+	code   int32
+	detail string
+	status string
 }
 
 func (e *Error) Error() string {
@@ -37,10 +37,10 @@ func (e *Error) Error() string {
 // New generates a custom error.
 func New(id, detail string, code int32) error {
 	return &Error{
-		Id:     id,
-		Code:   code,
-		Detail: detail,
-		Status: http.StatusText(int(code)),
+		id:     id,
+		code:   code,
+		detail: detail,
+		status: http.StatusText(int(code)),
 	}
 }
 
@@ -62,7 +62,7 @@ func Parse(err string) *Error {
 	e := new(Error)
 	errr := json.Unmarshal([]byte(err), e)
 	if errr != nil {
-		e.Detail = err
+		e.detail = err
 	}
 	return e
 }
@@ -70,120 +70,120 @@ func Parse(err string) *Error {
 // BadRequest generates a 400 error.
 func BadRequest(id, format string, a ...interface{}) error {
 	return &Error{
-		Id:     id,
-		Code:   400,
-		Detail: fmt.Sprintf(format, a...),
-		Status: http.StatusText(400),
+		id:     id,
+		code:   400,
+		detail: fmt.Sprintf(format, a...),
+		status: http.StatusText(400),
 	}
 }
 
 // Unauthorized generates a 401 error.
 func Unauthorized(id, format string, a ...interface{}) error {
 	return &Error{
-		Id:     id,
-		Code:   401,
-		Detail: fmt.Sprintf(format, a...),
-		Status: http.StatusText(401),
+		id:     id,
+		code:   401,
+		detail: fmt.Sprintf(format, a...),
+		status: http.StatusText(401),
 	}
 }
 
 // Forbidden generates a 403 error.
 func Forbidden(id, format string, a ...interface{}) error {
 	return &Error{
-		Id:     id,
-		Code:   403,
-		Detail: fmt.Sprintf(format, a...),
-		Status: http.StatusText(403),
+		id:     id,
+		code:   403,
+		detail: fmt.Sprintf(format, a...),
+		status: http.StatusText(403),
 	}
 }
 
 // NotFound generates a 404 error.
 func NotFound(id, format string, a ...interface{}) error {
 	return &Error{
-		Id:     id,
-		Code:   404,
-		Detail: fmt.Sprintf(format, a...),
-		Status: http.StatusText(404),
+		id:     id,
+		code:   404,
+		detail: fmt.Sprintf(format, a...),
+		status: http.StatusText(404),
 	}
 }
 
 // MethodNotAllowed generates a 405 error.
 func MethodNotAllowed(id, format string, a ...interface{}) error {
 	return &Error{
-		Id:     id,
-		Code:   405,
-		Detail: fmt.Sprintf(format, a...),
-		Status: http.StatusText(405),
+		id:     id,
+		code:   405,
+		detail: fmt.Sprintf(format, a...),
+		status: http.StatusText(405),
 	}
 }
 
 // Timeout generates a 408 error.
 func Timeout(id, format string, a ...interface{}) error {
 	return &Error{
-		Id:     id,
-		Code:   408,
-		Detail: fmt.Sprintf(format, a...),
-		Status: http.StatusText(408),
+		id:     id,
+		code:   408,
+		detail: fmt.Sprintf(format, a...),
+		status: http.StatusText(408),
 	}
 }
 
 // Conflict generates a 409 error.
 func Conflict(id, format string, a ...interface{}) error {
 	return &Error{
-		Id:     id,
-		Code:   409,
-		Detail: fmt.Sprintf(format, a...),
-		Status: http.StatusText(409),
+		id:     id,
+		code:   409,
+		detail: fmt.Sprintf(format, a...),
+		status: http.StatusText(409),
 	}
 }
 
 // InternalServerError generates a 500 error.
 func InternalServerError(id, format string, a ...interface{}) error {
 	return &Error{
-		Id:     id,
-		Code:   500,
-		Detail: fmt.Sprintf(format, a...),
-		Status: http.StatusText(500),
+		id:     id,
+		code:   500,
+		detail: fmt.Sprintf(format, a...),
+		status: http.StatusText(500),
 	}
 }
 
 // NotImplemented generates a 501 error
 func NotImplemented(id, format string, a ...interface{}) error {
 	return &Error{
-		Id:     id,
-		Code:   501,
-		Detail: fmt.Sprintf(format, a...),
-		Status: http.StatusText(501),
+		id:     id,
+		code:   501,
+		detail: fmt.Sprintf(format, a...),
+		status: http.StatusText(501),
 	}
 }
 
 // BadGateway generates a 502 error
 func BadGateway(id, format string, a ...interface{}) error {
 	return &Error{
-		Id:     id,
-		Code:   502,
-		Detail: fmt.Sprintf(format, a...),
-		Status: http.StatusText(502),
+		id:     id,
+		code:   502,
+		detail: fmt.Sprintf(format, a...),
+		status: http.StatusText(502),
 	}
 }
 
 // ServiceUnavailable generates a 503 error
 func ServiceUnavailable(id, format string, a ...interface{}) error {
 	return &Error{
-		Id:     id,
-		Code:   503,
-		Detail: fmt.Sprintf(format, a...),
-		Status: http.StatusText(503),
+		id:     id,
+		code:   503,
+		detail: fmt.Sprintf(format, a...),
+		status: http.StatusText(503),
 	}
 }
 
 // GatewayTimeout generates a 504 error
 func GatewayTimeout(id, format string, a ...interface{}) error {
 	return &Error{
-		Id:     id,
-		Code:   504,
-		Detail: fmt.Sprintf(format, a...),
-		Status: http.StatusText(504),
+		id:     id,
+		code:   504,
+		detail: fmt.Sprintf(format, a...),
+		status: http.StatusText(504),
 	}
 }
 
@@ -200,7 +200,7 @@ func Equal(err1 error, err2 error) bool {
 		return err1 == err2
 	}
 
-	if verr1.Code != verr2.Code {
+	if verr1.code != verr2.code {
 		return false
 	}
 

--- a/service/errors/errors_test.go
+++ b/service/errors/errors_test.go
@@ -22,12 +22,12 @@ import (
 func TestFromError(t *testing.T) {
 	err := NotFound("go.micro.test", "%s", "example")
 	merr := FromError(err)
-	if merr.Id != "go.micro.test" || merr.Code != 404 {
+	if merr.id != "go.micro.test" || merr.code != 404 {
 		t.Fatalf("invalid conversation %v != %v", err, merr)
 	}
 	err = er.New(err.Error())
 	merr = FromError(err)
-	if merr.Id != "go.micro.test" || merr.Code != 404 {
+	if merr.id != "go.micro.test" || merr.code != 404 {
 		t.Fatalf("invalid conversation %v != %v", err, merr)
 	}
 
@@ -51,15 +51,15 @@ func TestEqual(t *testing.T) {
 func TestErrors(t *testing.T) {
 	testData := []*Error{
 		{
-			Id:     "test",
-			Code:   500,
-			Detail: "Internal server error",
-			Status: http.StatusText(500),
+			id:     "test",
+			code:   500,
+			detail: "Internal server error",
+			status: http.StatusText(500),
 		},
 	}
 
 	for _, e := range testData {
-		ne := New(e.Id, e.Detail, e.Code)
+		ne := New(e.id, e.detail, e.code)
 
 		if e.Error() != ne.Error() {
 			t.Fatalf("Expected %s got %s", e.Error(), ne.Error())
@@ -71,20 +71,20 @@ func TestErrors(t *testing.T) {
 			t.Fatalf("Expected error got nil %v", pe)
 		}
 
-		if pe.Id != e.Id {
-			t.Fatalf("Expected %s got %s", e.Id, pe.Id)
+		if pe.id != e.id {
+			t.Fatalf("Expected %s got %s", e.id, pe.id)
 		}
 
-		if pe.Detail != e.Detail {
-			t.Fatalf("Expected %s got %s", e.Detail, pe.Detail)
+		if pe.detail != e.detail {
+			t.Fatalf("Expected %s got %s", e.detail, pe.detail)
 		}
 
-		if pe.Code != e.Code {
-			t.Fatalf("Expected %d got %d", e.Code, pe.Code)
+		if pe.code != e.code {
+			t.Fatalf("Expected %d got %d", e.code, pe.code)
 		}
 
-		if pe.Status != e.Status {
-			t.Fatalf("Expected %s got %s", e.Status, pe.Status)
+		if pe.status != e.status {
+			t.Fatalf("Expected %s got %s", e.status, pe.status)
 		}
 	}
 }


### PR DESCRIPTION
In my company is currently using micro, we found irregularities when making a successful response and a failed response especially during input validation. For the response we use the json standard, so for the first letter is lowercase, we encounter problems when giving a failed response because the first letter of the failed response is an uppercase letter. we hope micro fixes this to be able to use first lower case (camelCase) for failed responses, thanks.