### PR TITLE
resubmit: change error response to using lowercase for consistency response with success response based on standard JSON REST API

### DIFF
--- a/service/errors/errors.go
+++ b/service/errors/errors.go
@@ -23,10 +23,10 @@ import (
 )
 
 type Error struct {
-	Id     string
-	Code   int32
-	Detail string
-	Status string
+	Id     string `json:"id"`
+	Code   int32  `json:"code"`
+	Detail string `json:"detail"`
+	Status string `json:"status"`
 }
 
 func (e *Error) Error() string {


### PR DESCRIPTION
In my company is currently using micro, we found irregularities when making a successful response and a failed response especially during input validation. For the response we use the json standard, so for the first letter is lowercase, we encounter problems when giving a failed response because the first letter of the failed response is an uppercase letter. we hope micro fixes this to be able to use first lower case (camelCase) for failed responses, thanks.