### PR TITLE
Pass auth header through wss subprotocol header

### DIFF
--- a/cmd/dynamic_test.go
+++ b/cmd/dynamic_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -301,41 +302,13 @@ func TestDynamicFlagParsing(t *testing.T) {
 			values: &goregistry.Value{
 				Values: []*goregistry.Value{
 					{
-						Name: "user",
-						Values: []*goregistry.Value{
-							{
-								Name: "email",
-								Type: "string",
-							},
-						},
+						Name: "user_email",
+						Type: "string",
 					},
 				},
 			},
 			expected: map[string]interface{}{
-				"user": map[string]interface{}{
-					"email": "someemail",
-				},
-			},
-		},
-		{
-			args: []string{"--user_email", "someemail"},
-			values: &goregistry.Value{
-				Values: []*goregistry.Value{
-					{
-						Name: "user",
-						Values: []*goregistry.Value{
-							{
-								Name: "email",
-								Type: "string",
-							},
-						},
-					},
-				},
-			},
-			expected: map[string]interface{}{
-				"user": map[string]interface{}{
-					"email": "someemail",
-				},
+				"user_email": "someemail",
 			},
 		},
 		{
@@ -343,51 +316,18 @@ func TestDynamicFlagParsing(t *testing.T) {
 			values: &goregistry.Value{
 				Values: []*goregistry.Value{
 					{
-						Name: "user",
-						Values: []*goregistry.Value{
-							{
-								Name: "email",
-								Type: "string",
-							},
-							{
-								Name: "name",
-								Type: "string",
-							},
-						},
+						Name: "user_email",
+						Type: "string",
 					},
-				},
-			},
-			expected: map[string]interface{}{
-				"user": map[string]interface{}{
-					"email": "someemail",
-					"name":  "somename",
-				},
-			},
-		},
-		{
-			args: []string{"--user_email", "someemail", "--user_name", "somename"},
-			values: &goregistry.Value{
-				Values: []*goregistry.Value{
 					{
-						Name: "user",
-						Values: []*goregistry.Value{
-							{
-								Name: "email",
-								Type: "string",
-							},
-							{
-								Name: "name",
-								Type: "string",
-							},
-						},
+						Name: "user_name",
+						Type: "string",
 					},
 				},
 			},
 			expected: map[string]interface{}{
-				"user": map[string]interface{}{
-					"email": "someemail",
-					"name":  "somename",
-				},
+				"user_email": "someemail",
+				"user_name":  "somename",
 			},
 		},
 		{
@@ -409,42 +349,31 @@ func TestDynamicFlagParsing(t *testing.T) {
 			values: &goregistry.Value{
 				Values: []*goregistry.Value{
 					{
-						Name: "user",
-						Values: []*goregistry.Value{
-							{
-								Name: "friend",
-								Values: []*goregistry.Value{
-									{
-										Name: "email",
-										Type: "string",
-									},
-								},
-							},
-						},
+						Name: "user_friend_email",
+						Type: "string",
 					},
 				},
 			},
 			expected: map[string]interface{}{
-				"user": map[string]interface{}{
-					"friend": map[string]interface{}{
-						"email": "hi",
-					},
-				},
+				"user_friend_email": "hi",
 			},
 		},
 	}
 	for _, c := range cases {
-		_, flags, err := splitCmdArgs(c.args)
-		if err != nil {
-			t.Fatal(err)
-		}
-		req, err := flagsToRequest(flags, c.values)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !reflect.DeepEqual(c.expected, req) {
-			spew.Dump("Expected:", c.expected, "got: ", req)
-			t.Fatalf("Expected %v, got %v", c.expected, req)
-		}
+		t.Run(strings.Join(c.args, " "), func(t *testing.T) {
+			_, flags, err := splitCmdArgs(c.args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req, err := flagsToRequest(flags, c.values)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(c.expected, req) {
+				spew.Dump("Expected:", c.expected, "got: ", req)
+				t.Fatalf("Expected %v, got %v", c.expected, req)
+			}
+		})
+
 	}
 }

--- a/service/api/handler/rpc/stream.go
+++ b/service/api/handler/rpc/stream.go
@@ -357,7 +357,16 @@ func (s *stream) bufToClientLoop(cancel context.CancelFunc, wg *sync.WaitGroup, 
 
 // serveWebsocket will stream rpc back over websockets assuming json
 func serveWebsocket(ctx context.Context, w http.ResponseWriter, r *http.Request, service *api.Service, c client.Client) {
-	conn, err := upgrader.Upgrade(w, r, nil)
+	var rspHdr http.Header
+	// we use Sec-Websocket-Protocol to pass auth headers so just accept anything here
+	if prots := r.Header.Values("Sec-WebSocket-Protocol"); len(prots) > 0 {
+		rspHdr = http.Header{}
+		for _, p := range prots {
+			rspHdr.Add("Sec-WebSocket-Protocol", p)
+		}
+	}
+
+	conn, err := upgrader.Upgrade(w, r, rspHdr)
 	if err != nil {
 		if logger.V(logger.ErrorLevel, logger.DefaultLogger) {
 			logger.Error(err)


### PR DESCRIPTION
Useful because web clients can't use basic auth https://stackoverflow.com/questions/4361173/http-headers-in-websockets-client-api/4361358#4361358