### PR TITLE
support adding handlers

### DIFF
--- a/service/api/handler/context.go
+++ b/service/api/handler/context.go
@@ -1,0 +1,12 @@
+package handler
+
+import (
+	"github.com/micro/micro/v3/service/api"
+	"github.com/micro/micro/v3/service/client"
+)
+
+type Context interface {
+	Client() client.Client
+	Service() *api.Service
+	Domain() string
+}

--- a/service/api/handler/handler.go
+++ b/service/api/handler/handler.go
@@ -35,7 +35,7 @@ type Handler interface {
 	String() string
 }
 
-type APIHandler struct {}
+type APIHandler struct{}
 
 func (a *APIHandler) ReadBlockList(ctx context.Context, request *api.ReadBlockListRequest, response *api.ReadBlockListResponse) error {
 	if err := namespace.AuthorizeAdmin(ctx, namespace.DefaultNamespace, "api.API.AddToBlockList"); err != nil {

--- a/service/api/handler/http/http.go
+++ b/service/api/handler/http/http.go
@@ -66,9 +66,9 @@ func (h *httpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h *httpHandler) getService(r *http.Request) (string, error) {
 	var service *api.Service
 
-	if h.s != nil {
+	if v, ok := r.Context().(handler.Context); ok {
 		// we were given the service
-		service = h.s
+		service = v.Service()
 	} else if h.options.Router != nil {
 		// try get service from router
 		s, err := h.options.Router.Route(r)
@@ -106,15 +106,5 @@ func NewHandler(opts ...handler.Option) handler.Handler {
 
 	return &httpHandler{
 		options: options,
-	}
-}
-
-// WithService creates a handler with a service
-func WithService(s *api.Service, opts ...handler.Option) handler.Handler {
-	options := handler.NewOptions(opts...)
-
-	return &httpHandler{
-		options: options,
-		s:       s,
 	}
 }

--- a/service/api/handler/options.go
+++ b/service/api/handler/options.go
@@ -48,7 +48,7 @@ func NewOptions(opts ...Option) Options {
 
 	// set namespace if blank
 	if len(options.Namespace) == 0 {
-		WithNamespace("go.micro.api")(&options)
+		WithNamespace("micro")(&options)
 	}
 
 	if options.MaxRecvSize == 0 {

--- a/service/api/handler/web/web.go
+++ b/service/api/handler/web/web.go
@@ -72,9 +72,9 @@ func (wh *webHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (wh *webHandler) getService(r *http.Request) (string, error) {
 	var service *api.Service
 
-	if wh.s != nil {
+	if v, ok := r.Context().(handler.Context); ok {
 		// we were given the service
-		service = wh.s
+		service = v.Service()
 	} else if wh.opts.Router != nil {
 		// try get service from router
 		s, err := wh.opts.Router.Route(r)
@@ -184,14 +184,5 @@ func (wh *webHandler) String() string {
 func NewHandler(opts ...handler.Option) handler.Handler {
 	return &webHandler{
 		opts: handler.NewOptions(opts...),
-	}
-}
-
-func WithService(s *api.Service, opts ...handler.Option) handler.Handler {
-	options := handler.NewOptions(opts...)
-
-	return &webHandler{
-		opts: options,
-		s:    s,
 	}
 }

--- a/service/api/server/handler.go
+++ b/service/api/server/handler.go
@@ -1,26 +1,62 @@
 package api
 
 import (
+	"context"
 	"net/http"
 
-	"github.com/micro/micro/v3/service"
+	"github.com/micro/micro/v3/service/api"
 	"github.com/micro/micro/v3/service/api/handler"
-	"github.com/micro/micro/v3/service/api/handler/event"
 	"github.com/micro/micro/v3/service/api/router"
 	"github.com/micro/micro/v3/service/client"
 	"github.com/micro/micro/v3/service/errors"
 
-	// TODO: only import handler package
 	aapi "github.com/micro/micro/v3/service/api/handler/api"
+	"github.com/micro/micro/v3/service/api/handler/event"
 	ahttp "github.com/micro/micro/v3/service/api/handler/http"
-	arpc "github.com/micro/micro/v3/service/api/handler/rpc"
-	aweb "github.com/micro/micro/v3/service/api/handler/web"
+	"github.com/micro/micro/v3/service/api/handler/rpc"
+	"github.com/micro/micro/v3/service/api/handler/web"
 )
 
 type metaHandler struct {
 	c  client.Client
 	r  router.Router
 	ns string
+}
+
+var (
+	// built in handlers
+	handlers = map[string]handler.Handler{
+		"rpc":   rpc.NewHandler(),
+		"web":   web.NewHandler(),
+		"http":  ahttp.NewHandler(),
+		"event": event.NewHandler(),
+		"api":   aapi.NewHandler(),
+	}
+)
+
+// Register a handler
+func Register(handler string, hd handler.Handler) {
+	handlers[handler] = hd
+}
+
+// serverContext
+type serverContext struct {
+	context.Context
+	domain  string
+	client  client.Client
+	service *api.Service
+}
+
+func (c *serverContext) Service() *api.Service {
+	return c.service
+}
+
+func (c *serverContext) Client() client.Client {
+	return c.client
+}
+
+func (c *serverContext) Domain() string {
+	return c.domain
 }
 
 func (m *metaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -33,37 +69,39 @@ func (m *metaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO: don't do this ffs
-	switch service.Endpoint.Handler {
-	// web socket handler
-	case aweb.Handler:
-		aweb.WithService(service, handler.WithClient(m.c)).ServeHTTP(w, r)
-	// proxy handler
-	case ahttp.Handler:
-		ahttp.WithService(service, handler.WithClient(m.c)).ServeHTTP(w, r)
-	// rpcx handler
-	case arpc.Handler:
-		arpc.WithService(service, handler.WithClient(m.c)).ServeHTTP(w, r)
-	// event handler
-	case event.Handler:
-		ev := event.NewHandler(
-			handler.WithNamespace(m.ns),
-			handler.WithClient(m.c),
-		)
-		ev.ServeHTTP(w, r)
-	// api handler
-	case aapi.Handler:
-		aapi.WithService(service, handler.WithClient(m.c)).ServeHTTP(w, r)
-	// default handler: rpc
-	default:
-		arpc.WithService(service, handler.WithClient(m.c)).ServeHTTP(w, r)
+	// inject service into context
+	ctx := r.Context()
+	// create a new server context
+	srvContext := &serverContext{
+		Context: ctx,
+		domain:  m.ns,
+		client:  m.c,
+		service: service,
 	}
+	// clone request with new context
+	req := r.Clone(srvContext)
+
+	// get the necessary handler
+	hd := service.Endpoint.Handler
+	// retrieve the handler for the request
+	if len(hd) == 0 {
+		hd = "rpc"
+	}
+
+	hdr, ok := handlers[hd]
+	if !ok {
+		// use the catch all rpc handler
+		hdr = handlers["rpc"]
+	}
+
+	// serve the request
+	hdr.ServeHTTP(w, req)
 }
 
 // Meta is a http.Handler that routes based on endpoint metadata
-func Meta(s *service.Service, r router.Router, ns string) http.Handler {
+func Meta(c client.Client, r router.Router, ns string) http.Handler {
 	return &metaHandler{
-		c:  s.Client(),
+		c:  c,
 		r:  r,
 		ns: ns,
 	}


### PR DESCRIPTION
Add the ability to register additional handlers in the api

```
import "github.com/micro/micro/v3/service/api/server"

server.Register("v1", handler)
```

Syntax/location may change

Additionally support a context which includes the service and client

```
import "github.com/micro/micro/v3/service/api/handler"

ctx := r.Context().(handler.Context)

// ctx.Service()
// ctx.Client()
// ctx.Domain()
```

Again syntax/location may change