### PR TITLE
Add darwin-arm64 as an supported platform

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,7 +41,7 @@ getSystemInfo() {
 }
 
 checkSupported() {
-    local supported_osarch=(darwin-amd64 linux-amd64 linux-arm7 linux-arm64)
+    local supported_osarch=(darwin-amd64 darwin-arm64 linux-amd64 linux-arm7 linux-arm64)
     local machine_osarch="${OS}-${ARCH}"
 
     echo "Checking machine system support"


### PR DESCRIPTION
Added darwin-arm64 as an supported platform the make the install script work as intended on Apple Silicon Macs.

This will make sure the 'Get Started' guide is also easily followable on Apple Silicon Macs. 
[https://github.com/micro/micro#install-binaries](https://github.com/micro/micro#install-binaries)