### PR TITLE
add prefix dns k8s

### DIFF
--- a/service/router/kubernetes/kubernetes.go
+++ b/service/router/kubernetes/kubernetes.go
@@ -17,9 +17,18 @@ package kubernetes
 
 import (
 	"fmt"
-
 	"github.com/micro/micro/v3/service/router"
+	"os"
 )
+
+var prefixDns string = "cluster.local"
+
+func init() {
+	prefix, ok := os.LookupEnv("K8S_DNS_PREFIX")
+	if ok {
+		prefixDns = prefix
+	}
+}
 
 // NewRouter returns an initialized kubernetes router
 func NewRouter(opts ...router.Option) router.Router {
@@ -55,7 +64,7 @@ func (k *kubernetes) Lookup(service string, opts ...router.LookupOption) ([]rout
 		options.Network = "micro"
 	}
 
-	address := fmt.Sprintf("%v.%v.svc.cluster.local:8080", service, options.Network)
+	address := fmt.Sprintf("%v.%v.svc.%s:8080", service, options.Network, prefixDns)
 
 	return []router.Route{
 		router.Route{


### PR DESCRIPTION
**Add Environmentprefix dns k8s `K8S_DNS_PREFIX`** 

Default dns when using k8s is `cluster.local` but when using k8s with k8s custom or change dns default . Micro not find service because not match name service.