### PR TITLE
auth/rules: compare strings with `strings.EqualFold`

### DIFF
--- a/util/auth/rules/rules.go
+++ b/util/auth/rules/rules.go
@@ -112,7 +112,7 @@ func VerifyAccess(rules []*auth.Rule, acc *auth.Account, res *auth.Resource, opt
 // not case sensitive.
 func include(slice []string, val string) bool {
 	for _, s := range slice {
-		if strings.ToLower(s) == strings.ToLower(val) {
+		if strings.EqualFold(s, val) {
 			return true
 		}
 	}


### PR DESCRIPTION
Comparing two strings to the same case with `strings.ToLower` is more computational expensive than `strings.EqualFold`.

Sample benchmark:

```go
func BenchmarkToLower(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if strings.ToLower("FOOBAR") != strings.ToLower("foobar") {
			b.Fail()
		}
	}
}

func BenchmarkEqualFold(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if !strings.EqualFold("FOOBAR", "foobar") {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: micro.dev/v4/util/auth/rules
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkToLower-16      	22834522	        99.96 ns/op	       8 B/op	       1 allocs/op
BenchmarkEqualFold-16    	151317182	         8.163 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	micro.dev/v4/util/auth/rules	4.104s
```