### PR TITLE
improve and fix #2060

### DIFF
--- a/cmd/client/new/new.go
+++ b/cmd/client/new/new.go
@@ -25,7 +25,7 @@ func protoComments(goDir, alias string) []string {
 		"\ncompile the proto file " + alias + ".proto:\n",
 		"cd " + alias,
 		"make init",
-		"go mod vendor",
+		"go mod tidy",
 		"make proto\n",
 	}
 }
@@ -35,6 +35,8 @@ type config struct {
 	Alias string
 	// github.com/micro/foo
 	Dir string
+	// UseGoVersion
+	GoVersion string
 	// $GOPATH/src/github.com/micro/foo
 	GoDir string
 	// $GOPATH
@@ -171,10 +173,16 @@ func Run(ctx *cli.Context) error {
 	}
 	goDir = filepath.Join(goPath, "src", path.Clean(dir))
 
+	goVersion := runtime.Version()
+	if strings.HasPrefix(goVersion, "go") {
+		goVersion = strings.TrimPrefix(goVersion, "go")
+	}
+
 	c := config{
 		Alias:     dir,
 		Comments:  protoComments(goDir, dir),
 		Dir:       dir,
+		GoVersion: goVersion,
 		GoDir:     goDir,
 		GoPath:    goPath,
 		UseGoPath: false,

--- a/cmd/client/new/new.go
+++ b/cmd/client/new/new.go
@@ -20,13 +20,10 @@ import (
 
 func protoComments(goDir, alias string) []string {
 	return []string{
-		"\ndownload protoc zip packages (protoc-$VERSION-$PLATFORM.zip) and install:\n",
-		"visit https://github.com/protocolbuffers/protobuf/releases",
-		"\ncompile the proto file " + alias + ".proto:\n",
 		"cd " + alias,
-		"make init",
 		"go mod tidy",
-		"make proto\n",
+		"make proto",
+		"micro run .\n",
 	}
 }
 
@@ -190,6 +187,7 @@ func Run(ctx *cli.Context) error {
 			{"main.go", tmpl.MainSRV},
 			{"handler/" + dir + ".go", tmpl.HandlerSRV},
 			{"proto/" + dir + ".proto", tmpl.ProtoSRV},
+			{"dep-install.mk", tmpl.DepInstall},
 			{"Makefile", tmpl.Makefile},
 			{"README.md", tmpl.Readme},
 			{".gitignore", tmpl.GitIgnore},

--- a/cmd/client/new/template/dep-install.go
+++ b/cmd/client/new/template/dep-install.go
@@ -1,0 +1,61 @@
+package template
+
+var (
+	DepInstall = `PROTOC_GEN_GO := $(GOBIN)/protoc-gen-go
+PROTOC_GEN_MICRO := $(GOBIN)/protoc-gen-micro
+PROTOC = $(shell which protoc || echo "$(GOBIN)/protoc")
+
+# Generate protoc latest binary url
+PROTOC_RELEASE_BIN := protoc
+ifeq ($(GOOS), linux)
+	ifeq ($(GOARCH), amd64)
+		PROTOC_RELEASE = linux-x86_64
+	else ifeq ($(GOARCH), arm64)
+		PROTOC_RELEASE = linux-aarch_64
+	else ifeq ($(GOARCH), 386)
+		PROTOC_RELEASE = linux-x86_32
+	else
+		echo >&2 "only support amd64, arm64 or 386 GOARCH" && exit 1
+	endif
+else ifeq ($(GOOS), darwin)
+	ifeq ($(GOARCH), amd64)
+		PROTOC_RELEASE = osx-x86_64
+	else ifeq ($(GOARCH), arm64)
+		PROTOC_RELEASE = osx-aarch_64
+	else
+		echo >&2 "only support amd64 or arm64 GOARCH" && exit 1
+	endif
+else ifeq ($(GOOS), windows)
+	ifeq ($(GOARCH), amd64)
+		PROTOC_RELEASE = win64
+	else ifeq ($(GOARCH), 386)
+		PROTOC_RELEASE = win32
+	else
+		echo >&2 "only support amd64 or 386 GOARCH" && exit 1
+	endif
+PROTOC_RELEASE_BIN = protoc.exe
+endif
+PROTOC_LATEST = https://github.com/protocolbuffers/protobuf/releases/latest
+PROTOC_VERSION = $(shell curl -Ls -o /dev/null -w %{url_effective} $(PROTOC_LATEST) | sed 's|.*/v||')
+PROTOC_RELEASE_URL = https://github.com/protocolbuffers/protobuf/releases/download/v$(PROTOC_VERSION)/protoc-$(PROTOC_VERSION)-$(PROTOC_RELEASE).zip
+
+# Install dependencies
+.PHONY: init
+init: $(PROTOC) $(PROTOC_GEN_GO) $(PROTOC_GEN_MICRO)
+
+# Install protoc latest binary
+# from release https://github.com/protocolbuffers/protobuf/releases
+# to $(GOBIN)
+$(PROTOC):
+	curl -LSs $(PROTOC_RELEASE_URL) -o protoc.zip
+	unzip -qqj protoc.zip "bin/$(PROTOC_RELEASE_BIN)" -d "$(GOBIN)" && rm protoc.zip
+
+# Install protoc-gen-go
+$(PROTOC_GEN_GO):
+	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+
+# Install protoc-gen-micro
+$(PROTOC_GEN_MICRO):
+	go install micro.dev/v4/cmd/protoc-gen-micro@master
+`
+)

--- a/cmd/client/new/template/makefile.go
+++ b/cmd/client/new/template/makefile.go
@@ -1,20 +1,36 @@
 package template
 
 var (
-	Makefile = `
-GOPATH:=$(shell go env GOPATH)
-.PHONY: init
-init:
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-	go install micro.dev/v4/cmd/protoc-gen-micro@master
+	Makefile = `GOOS := $(shell go env GOOS)
+GOARCH := $(shell go env GOARCH)
+GOBIN := $(shell go env GOPATH)/bin
+NAME := $(shell  basename $(CURDIR))
+ifeq ($(GOOS),windows)
+	TARGET := $(NAME).exe
+else
+	TARGET := $(NAME)
+endif
+PROTO_FILES := $(wildcard proto/*.proto)
+PROTO_GO := $(PROTO_FILES:%.proto=%.pb.go)
+PROTO_GO_MICRO := $(PROTO_FILES:%.proto=%.pb.micro.go)
+
+.DEFAULT_GOAL := $(TARGET)
+
+# Build binary
+$(TARGET): proto/$(NAME).pb.micro.go
+	go build -o $(TARGET) *.go
+
+.PHONY: clean
+clean:
+	rm -f $(TARGET) $(PROTO_GO) $(PROTO_GO_MICRO)
+
+include dep-install.mk
 
 .PHONY: proto
-proto:
-	protoc --proto_path=. --micro_out=. --go_out=:. proto/{{.Alias}}.proto
+proto: proto/$(NAME).pb.micro.go
 
-.PHONY: build
-build:
-	go build -o {{.Alias}} *.go
+%.pb.go %.pb.micro.go:
+	protoc --proto_path=. --go_out=:. --micro_out=. $(*).proto
 
 .PHONY: test
 test:
@@ -22,6 +38,6 @@ test:
 
 .PHONY: docker
 docker:
-	docker build . -t {{.Alias}}:latest
+	docker build . -t $(NAME):latest
 `
 )

--- a/cmd/client/new/template/makefile.go
+++ b/cmd/client/new/template/makefile.go
@@ -6,17 +6,12 @@ GOPATH:=$(shell go env GOPATH)
 .PHONY: init
 init:
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-	go install micro.dev/v4/cmd/protoc-gen-micro@latest
-	go install micro.dev/v4/cmd/protoc-gen-openapi@latest
-
-.PHONY: api
-api:
-	protoc --openapi_out=. --proto_path=. proto/{{.Alias}}.proto
+	go install micro.dev/v4/cmd/protoc-gen-micro@master
 
 .PHONY: proto
 proto:
 	protoc --proto_path=. --micro_out=. --go_out=:. proto/{{.Alias}}.proto
-	
+
 .PHONY: build
 build:
 	go build -o {{.Alias}} *.go

--- a/cmd/client/new/template/module.go
+++ b/cmd/client/new/template/module.go
@@ -3,16 +3,12 @@ package template
 var (
 	Module = `module {{.Dir}}
 
-go 1.18
+go {{.GoVersion}}
 
 require (
-	github.com/golang/protobuf latest
 	micro.dev/v4 latest
 	google.golang.org/protobuf latest
+	google.golang.org/grpc latest
 )
-
-// This can be removed once etcd becomes go gettable, version 3.4 and 3.5 is not,
-// see https://github.com/etcd-io/etcd/issues/11154 and https://github.com/etcd-io/etcd/issues/11931.
-replace google.golang.org/grpc => google.golang.org/grpc v1.27.1
 `
 )

--- a/cmd/client/new/template/module.go
+++ b/cmd/client/new/template/module.go
@@ -5,10 +5,6 @@ var (
 
 go {{.GoVersion}}
 
-require (
-	micro.dev/v4 latest
-	google.golang.org/protobuf latest
-	google.golang.org/grpc latest
-)
+require micro.dev/v4 latest
 `
 )


### PR DESCRIPTION
- fix `protoc-gen-micro` install dep to @master version
- `protoc` install with make target
- current version of Go in go.mod
- universal, advanced makefile (can be reused in other service code by copy/paste)
- simplify `new` post instruction