### PR TITLE
run the service

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ micro version v5.0.0
 
 Create your service using [Go Micro](https://go-micro.dev)
 
+Run your service
+
+```
+micro run
+```
+
 List your services
 
 ```

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -225,6 +226,17 @@ func mcpHandler(c *cli.Context) error {
 	return server.ServeStdio(s)
 }
 
+func runHandler(c *cli.Context) error {
+	dir := c.Args().Get(0)
+	if len(dir) == 0 {
+		dir = "."
+	}
+	cmd := exec.Command("go", "run", dir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
 func main() {
 	cmd.App().Commands = []*cli.Command{{
 		Name:  "api",
@@ -238,6 +250,11 @@ func main() {
 			Name:   "mcp",
 			Usage:  "Run the MCP server",
 			Action: mcpHandler,
+		},
+		{
+			Name:   "run",
+			Usage:  "Run a service",
+			Action: runHandler,
 		},
 		{
 			Name:  "services",


### PR DESCRIPTION
This is nothing more than syntactic sugar for the moment on top of `go run` BUT the idea is if we control the run command, we can then allow detaching, build binaries, separate logs, introduce a `kill` command, file watching, etc.