### PR TITLE
Run web

### DIFF
--- a/cmd/micro-run/run.go
+++ b/cmd/micro-run/run.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 
 	"github.com/urfave/cli/v2"
-	"go-micro.dev/v5/cmd"
 	"go-micro.dev/v5/client"
+	"go-micro.dev/v5/cmd"
 	"go-micro.dev/v5/codec/bytes"
 	"go-micro.dev/v5/registry"
 )
@@ -378,7 +378,7 @@ func init() {
 		Name:   "run",
 		Usage:  "Run all services in a directory",
 		Action: Run,
-		Flags: []*cli.Flag{
+		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "address",
 				Aliases: []string{"a"},

--- a/cmd/micro-run/run.go
+++ b/cmd/micro-run/run.go
@@ -1,7 +1,8 @@
 package run
 
 import (
-	"bytes"
+	"context"
+	"encoding/json"
 	"fmt"
 	"bufio"
 	"io"
@@ -16,6 +17,8 @@ import (
 	"github.com/urfave/cli/v2"
 	"go-micro.dev/v5/cmd"
 	"go-micro.dev/v5/registry"
+	"go-micro.dev/v5/client"
+	"go-micro.dev/v5/codec/bytes"
 )
 
 // Color codes for log output

--- a/cmd/micro-run/run.go
+++ b/cmd/micro-run/run.go
@@ -31,8 +31,13 @@ func colorFor(idx int) string {
 }
 
 func serveMicroWeb(dir string) {
-	webDir := filepath.Join(dir, "web")
-	parentDir := filepath.Base(dir)
+	// Always resolve to absolute path for dir
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		absDir = dir // fallback
+	}
+	webDir := filepath.Join(absDir, "web")
+	parentDir := filepath.Base(absDir)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if _, err := os.Stat(webDir); err == nil {

--- a/cmd/micro-run/run.go
+++ b/cmd/micro-run/run.go
@@ -128,7 +128,16 @@ func Run(c *cli.Context) error {
 	var pidFiles []string
 	for i, mainFile := range mainFiles {
 		serviceDir := filepath.Dir(mainFile)
-		serviceName := filepath.Base(serviceDir)
+		var serviceName string
+		absDir, _ := filepath.Abs(dir)
+		absServiceDir, _ := filepath.Abs(serviceDir)
+		if absDir == absServiceDir {
+			// If main.go is in the root dir being run, use the current working dir name
+			cwd, _ := os.Getwd()
+			serviceName = filepath.Base(cwd)
+		} else {
+			serviceName = filepath.Base(serviceDir)
+		}
 		logFilePath := filepath.Join(logsDir, serviceName+".log")
 		binPath := filepath.Join(binDir, serviceName)
 		pidFilePath := filepath.Join(runDir, serviceName+".pid")

--- a/main.go
+++ b/main.go
@@ -20,9 +20,9 @@ import (
 
 	_ "github.com/micro/micro/v5/cmd/micro-api"
 	_ "github.com/micro/micro/v5/cmd/micro-cli"
-	_ "github.com/micro/micro/v5/cmd/micro-web"
-	_ "github.com/micro/micro/v5/cmd/micro-run"
 	"github.com/micro/micro/v5/cmd/micro-cli/util"
+	_ "github.com/micro/micro/v5/cmd/micro-run"
+	_ "github.com/micro/micro/v5/cmd/micro-web"
 )
 
 var (


### PR DESCRIPTION
So expanding micro run a bit.

- Removing `--all`, now the default behaviour. We will walk the sub-tree to find all main.go files and run those apps
- In the event we find a `web` dir we're going to assume the parent is the app and so we'll reverse proxy to it
  * e.g blog/web is a subdir, and it registered a go-micro/web service as blog, we'll look that up and proxy to it
- If no web dir is present we'll just try serve micro web and provide a list of services with dynamic form fill