### PR TITLE
fix 'go install' for protoc-gen-openapi

### DIFF
--- a/cmd/micro-cli/new/template/makefile.go
+++ b/cmd/micro-cli/new/template/makefile.go
@@ -7,7 +7,7 @@ GOPATH:=$(shell go env GOPATH)
 init:
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	go install github.com/micro/micro/v5/cmd/protoc-gen-micro@latest
-	go install github.com/micro/micro/v5/cmd/protoc-gen-openapi@latest
+	go install github.com/google/gnostic/cmd/protoc-gen-openapi@latest
 
 .PHONY: api
 api:


### PR DESCRIPTION
```
go install github.com/micro/micro/v5/cmd/protoc-gen-openapi@latest
```
does not work, it should be:
```
go install github.com/google/gnostic/cmd/protoc-gen-openapi@latest
```